### PR TITLE
Add UNIX timestamp to images to help browser cache invalidation

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -151,6 +151,8 @@ class Blockreassurance extends Module implements WidgetInterface
     {
         $html = '';
         $id_reassurance = (int)Tools::getValue('id_reassurance');
+        $date = new DateTime();
+        $timestamp = $date->getTimestamp();
 
         if (Tools::isSubmit('saveblockreassurance')) {
             if ($id_reassurance = Tools::getValue('id_reassurance')) {
@@ -170,12 +172,12 @@ class Blockreassurance extends Module implements WidgetInterface
                         return false;
                     } elseif (!($tmpName = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !move_uploaded_file($_FILES['image']['tmp_name'], $tmpName)) {
                         return false;
-                    } elseif (!ImageManager::resize($tmpName, dirname(__FILE__).'/img/reassurance-'.(int)$reassurance->id.'-'.(int)$reassurance->id_shop.'.jpg')) {
+                    } elseif (!ImageManager::resize($tmpName, dirname(__FILE__).'/img/reassurance-'.(int)$reassurance->id.'-'.(int)$reassurance->id_shop.'-'.$timestamp.'.jpg')) {
                         return false;
                     }
 
                     unlink($tmpName);
-                    $reassurance->file_name = 'reassurance-'.(int)$reassurance->id.'-'.(int)$reassurance->id_shop.'.jpg';
+                    $reassurance->file_name = 'reassurance-'.(int)$reassurance->id.'-'.(int)$reassurance->id_shop.'-'.$timestamp.'.jpg';
                     $reassurance->save();
                 }
                 $this->_clearCache('*');


### PR DESCRIPTION
Previously, if you'd replace a reassurance item image, the new image would get the same filename as the old one, meaning that on client side, the user should force refresh the browser page in order to see the new image.
This PR adds the UNIX timestamp in each new uploaded image file name, to force browser cache invalidation for the image.
