### PR TITLE
Add title and description properties

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -485,6 +485,8 @@ class blockreassurance extends Module implements WidgetInterface
             }
 
             $elements[$key]['text'] = $value['title'] . ' ' . $value['description'];
+            $elements[$key]['title'] = $value['title'];
+            $elements[$key]['description'] = $value['description'];
         }
 
         return [


### PR DESCRIPTION
Make title and description properties available for template separately. Keep text property for retro compatibility.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Made title and description property available for template. They are in different form fields in back-office but there is just "text" available for template so title and description can't be split for display. I just added the two properties to element, but maybe a better improvement will be to update template as well (replace text by title + description)
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Update template to use Smarty variables `{$element.title}` and `{$element.description}`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
