### PR TITLE
Fix compatibility range

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -133,7 +133,7 @@ class blockreassurance extends Module implements WidgetInterface
         // Confirm uninstall
         $this->confirmUninstall = $this->trans('Are you sure you want to uninstall this module?', [], 'Modules.Blockreassurance.Admin');
         $this->ps_url = $this->context->link->getBaseLink();
-        $this->ps_versions_compliancy = ['min' => '1.7', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.7.0', 'max' => _PS_VERSION_];
         $this->templateFile = 'module:blockreassurance/views/templates/hook/blockreassurance.tpl';
     }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | According to https://github.com/PrestaShop/blockreassurance/pull/47#issuecomment-647456624 v5.0.0 should be compatible with PS 1.7.7 and higher. I fix the compatibility range
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/20254
| How to test?  | Module should only be installable on PS 1.7.7

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
