### PR TITLE
Vars for links in some home pages templates

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -468,6 +468,8 @@ class blockreassurance extends Module implements WidgetInterface
                 $elements[$key]['image'] = '';
             }
 
+            $elements[$key]['link'] = $value['link'];
+            $elements[$key]['type_link'] = $value['type_link'];
             $elements[$key]['text'] = $value['title'] . ' ' . $value['description'];
             $elements[$key]['title'] = $value['title'];
             $elements[$key]['description'] = $value['description'];


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | adding 2 vars to use links in home page block with some templates
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | 1. Set a link on a reassurance block in Admin. 2. use the {$element['link']} tag in the loop in the blockreassurance.tpl, l.29 in your custom theme  3. validate that the variable is available

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
