### PR TITLE
Expose full blocks as widget elements

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -458,23 +458,20 @@ class blockreassurance extends Module implements WidgetInterface
             $this->context->shop->id
         );
 
-        $elements = [];
         foreach ($blocks as $key => $value) {
             if (!empty($value['icon'])) {
-                $elements[$key]['image'] = $value['icon'];
+                $blocks[$key]['image'] = $value['icon'];
             } elseif (!empty($value['custom_icon'])) {
-                $elements[$key]['image'] = $value['custom_icon'];
+                $blocks[$key]['image'] = $value['custom_icon'];
             } else {
-                $elements[$key]['image'] = '';
+                $blocks[$key]['image'] = '';
             }
 
-            $elements[$key]['text'] = $value['title'] . ' ' . $value['description'];
-            $elements[$key]['title'] = $value['title'];
-            $elements[$key]['description'] = $value['description'];
+            $blocks[$key]['text'] = $value['title'] . ' ' . $value['description'];
         }
 
         return [
-            'elements' => $elements,
+            'elements' => $blocks,
         ];
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Instead of returning a short object containing only the bits of data necessary for display, return full "block reassurance blocks" for widgets as it helps developer to extend the module as expressed in https://github.com/PrestaShop/PrestaShop/issues/21752
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/21752
| How to test?  | See ticket

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
