### PR TITLE
Fix replace slash on custom icon

### DIFF
--- a/classes/ReassuranceActivity.php
+++ b/classes/ReassuranceActivity.php
@@ -187,7 +187,7 @@ class ReassuranceActivity extends ObjectModel
 
         foreach ($result as &$item) {
             $item['is_svg'] = !empty($item['custom_icon'])
-                && (self::getMimeType(str_replace(__PS_BASE_URI__, _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR, $item['custom_icon'])) == 'image/svg');
+                && (self::getMimeType(preg_replace('/\\'.__PS_BASE_URI__.'/', _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR, $item['custom_icon'], 1)) == 'image/svg');
         }
 
         return $result;


### PR DESCRIPTION
Hi,

I'm coming with a little fix. When we upload a custom image, Mime type is checked via a PS method.

We need to pass full path of file. `__PS_BASE_URI__` is replaced by project directory. Ok but sometimes, that constant is equal to `/` so we replace all `/` by project directory on `/modules/blockreassurance/views...`

With that fix, we check only first occurence of `/` on that string.