### PR TITLE
Fix wrong custom icon path

### DIFF
--- a/classes/ReassuranceActivity.php
+++ b/classes/ReassuranceActivity.php
@@ -187,7 +187,7 @@ class ReassuranceActivity extends ObjectModel
 
         foreach ($result as &$item) {
             $item['is_svg'] = !empty($item['custom_icon'])
-                && (self::getMimeType(str_replace(__PS_BASE_URI__, _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR, $item['custom_icon'])) == 'image/svg');
+                && (self::getMimeType(_PS_ROOT_DIR_ . $item['custom_icon']) == 'image/svg');
         }
 
         return $result;

--- a/controllers/admin/AdminBlockListingController.php
+++ b/controllers/admin/AdminBlockListingController.php
@@ -76,7 +76,7 @@ class AdminBlockListingController extends ModuleAdminController
             $result = true;
             // Remove Custom icon
             if (!empty($blockPSR['custom_icon'])) {
-                $filePath = str_replace(__PS_BASE_URI__, _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR, $blockPSR['custom_icon']);
+                $filePath = _PS_ROOT_DIR_ . $blockPSR['custom_icon'];
                 if (file_exists($filePath)) {
                     $result = unlink($filePath);
                 }


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR fixes wrong custom icon path of reassurance item that generates a PHP warning.
| Type?         | bug fix
| BC breaks?    | -
| Deprecations? | -
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/23286.
| How to test?  | See below

#### How to test?

* Enable debug mode
* Add reassurance item with custom icon
* Before : PHP warning / After : no more PHP warning

#### Additional information

* PrestaShop version: 1.7.7.4
* `blockreassurance` version: 5.0.0

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
