### PR TITLE
Remove heading capitalization

### DIFF
--- a/_dev/back/back.scss
+++ b/_dev/back/back.scss
@@ -191,7 +191,6 @@
     line-height: 1.2;
     margin: 0;
     padding: 12px 20px !important;
-    text-transform: capitalize;
 }
 #content.bootstrap .panel .panel-footer {
     background-color: #f5f5f5;


### PR DESCRIPTION
Many languages don't use title case, so forcing it by CSS makes the headings look weird. In my language, title case prepositions are a definite no-no.
Let every language decide if it'll use capitalization when doing the translation. Or make it upper case - I think that would be gramarly ok, although less flexible.

<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | PrestaShop 1.7.8.0 beta1
| Type?         | bug fix
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | 
| How to test?  | The config form header's capitalization matches the translation's capitalization.

![before](https://user-images.githubusercontent.com/6468893/132991842-063d40fa-89b8-4f6c-8a06-f5c049ba4cb6.png)

![after](https://user-images.githubusercontent.com/6468893/132991852-44f4033c-c167-4965-b995-d1ffe4ce5e23.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
