### PR TITLE
Wrong image filename if base uri is slash

### DIFF
--- a/classes/ReassuranceActivity.php
+++ b/classes/ReassuranceActivity.php
@@ -187,7 +187,9 @@ class ReassuranceActivity extends ObjectModel
 
         foreach ($result as &$item) {
             $item['is_svg'] = !empty($item['custom_icon'])
-                && (self::getMimeType(str_replace(__PS_BASE_URI__, _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR, $item['custom_icon'])) == 'image/svg');
+                && (self::getMimeType(
+                    (__PS_BASE_URI__ == "/") ? _PS_ROOT_DIR_.DIRECTORY_SEPARATOR.$item['custom_icon'] : str_replace(__PS_BASE_URI__, _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR, $item['custom_icon'])
+                ) == 'image/svg');
         }
 
         return $result;

--- a/classes/ReassuranceActivity.php
+++ b/classes/ReassuranceActivity.php
@@ -188,7 +188,7 @@ class ReassuranceActivity extends ObjectModel
         foreach ($result as &$item) {
             $item['is_svg'] = !empty($item['custom_icon'])
                 && (self::getMimeType(
-                    (__PS_BASE_URI__ == "/") ? _PS_ROOT_DIR_.DIRECTORY_SEPARATOR.$item['custom_icon'] : str_replace(__PS_BASE_URI__, _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR, $item['custom_icon'])
+                    (__PS_BASE_URI__ == '/') ? _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR . $item['custom_icon'] : str_replace(__PS_BASE_URI__, _PS_ROOT_DIR_ . DIRECTORY_SEPARATOR, $item['custom_icon'])
                 ) == 'image/svg');
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If the base uri is only "/" then all occurrences of "/" in the custom_icon is replaced with the root directory. <br/><br/>Example : custom_icon = "/modules/blockreassurance/views/img/img_perso/clipart3043529.png"<br/><br/>Result : "/DataVolume/web-project/prestashop/chestergarden/www/modules/DataVolume/web-project/prestashop/chestergarden/www/blockreassurance/DataVolume/web-project/prestashop/chestergarden/www/views/DataVolume/web- project/prestashop/chestergarden/www/img/DataVolume/web-project/prestashop/chestergarden/www/img_perso/DataVolume/web-project/prestashop/chestergarden/www/clipart3043529.png"
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes [#25458.](https://github.com/PrestaShop/PrestaShop/issues/25458)
| How to test?  | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
