### PR TITLE
Fix filepath when checking filetype

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -486,7 +486,7 @@ class blockreassurance extends Module implements WidgetInterface
         $id_lang = $this->context->language->id;
 
         $this->context->smarty->assign([
-            'blocks' => ReassuranceActivity::getAllBlockByStatus($id_lang),
+            'blocks' => ReassuranceActivity::getAllBlockByStatus($id_lang, $this->folder_file_upload),
             'iconColor' => Configuration::get('PSR_ICON_COLOR'),
             'textColor' => Configuration::get('PSR_TEXT_COLOR'),
             // constants

--- a/classes/ReassuranceActivity.php
+++ b/classes/ReassuranceActivity.php
@@ -178,8 +178,7 @@ class ReassuranceActivity extends ObjectModel
         $xmlMimes = ['image/svg', 'image/svg+xml'];
         foreach ($result as &$item) {
             $filename = basename($item['custom_icon']);
-            $filepath = $filepath . $filename;
-            $mimeType = self::getMimeType($filepath);
+            $mimeType = self::getMimeType($filepath . $filename);
             $item['is_svg'] = !empty($item['custom_icon'])
                 && (in_array($mimeType, $xmlMimes));
         }

--- a/classes/ReassuranceActivity.php
+++ b/classes/ReassuranceActivity.php
@@ -30,7 +30,17 @@ class ReassuranceActivity extends ObjectModel
     const TYPE_LINK_URL = 2;
 
     public $id;
+    /**
+     * @var string Relative URI to the used icon
+     *
+     * Example: /ps1778/modules/blockreassurance/views/img/reassurance/pack2/carrier.svg
+     */
     public $icon;
+    /**
+     * @var string Relative URI to the used icon, for custom icons
+     *
+     * Example: /ps1778/modules/blockreassurance/views/img/img_perso/puffin_installer.png
+     */
     public $custom_icon;
     public $title;
     public $description;
@@ -149,12 +159,13 @@ class ReassuranceActivity extends ObjectModel
 
     /**
      * @param int $id_lang
+     * @param string $filepath Used to find the filepath of custom icons and images
      *
      * @return array
      *
      * @throws PrestaShopDatabaseException
      */
-    public static function getAllBlockByStatus($id_lang = 1)
+    public static function getAllBlockByStatus($id_lang = 1, $filepath = null)
     {
         $sql = 'SELECT * FROM `' . _DB_PREFIX_ . 'psreassurance` pr
             LEFT JOIN ' . _DB_PREFIX_ . 'psreassurance_lang prl ON (pr.id_psreassurance = prl.id_psreassurance)
@@ -166,8 +177,11 @@ class ReassuranceActivity extends ObjectModel
 
         $xmlMimes = ['image/svg', 'image/svg+xml'];
         foreach ($result as &$item) {
+            $filename = basename($item['custom_icon']);
+            $filepath = $filepath . $filename;
+            $mimeType = self::getMimeType($filepath);
             $item['is_svg'] = !empty($item['custom_icon'])
-                && (in_array(self::getMimeType(_PS_ROOT_DIR_ . $item['custom_icon']), $xmlMimes));
+                && (in_array($mimeType, $xmlMimes));
         }
 
         return $result;


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In ReassuranceActivity, the code was trying to find the mimetype of a custom icon. To do so it needed the filepath, and tried to recompute the filepath using `custom_icon` . I fixed the way the filepath is recomputed because with subfolder it would fail. The new way to build the filepath is the reverse operation of the initial way to build the upload file path.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/28264
| How to test?  | Follow ticket instructions, see below

# How to test

1. Install PrestaShop 1.7.8.x **in a subfolder** ⚠️ 
2. Go to BO > Module manager > search the blockreassurance module and click on configure
3. Add one block with custom PNG image
4. Activate the block
5. Go to FO > View product
6. No more error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
