### PR TITLE
Fix icon are next to each other when non-default language info is empty

### DIFF
--- a/_dev/front/front.scss
+++ b/_dev/front/front.scss
@@ -60,7 +60,7 @@
 }
 
 
-.blockreassurance_product >div {    
+.blockreassurance_product > div {    
     min-height: 40px;
 }
 

--- a/_dev/front/front.scss
+++ b/_dev/front/front.scss
@@ -59,11 +59,6 @@
     width: 35px;
 }
 
-
-.blockreassurance_product > div {    
-    min-height: 40px;
-}
-
 .blockreassurance_product p.block-title {
     line-height: 40px;    
 }

--- a/_dev/front/front.scss
+++ b/_dev/front/front.scss
@@ -61,6 +61,7 @@
 
 .blockreassurance_product p.block-title {
     line-height: 40px;
+    min-height: 5px;
 }
 
 /* Specific Checkout */

--- a/_dev/front/front.scss
+++ b/_dev/front/front.scss
@@ -59,9 +59,17 @@
     width: 35px;
 }
 
+
+.blockreassurance_product >div {    
+    min-height: 40px;
+}
+
 .blockreassurance_product p.block-title {
-    line-height: 40px;
-    min-height: 5px;
+    line-height: 40px;    
+}
+
+.blockreassurance_product p {    
+    min-height: 20px;
 }
 
 /* Specific Checkout */

--- a/views/templates/hook/displayBlockProduct.tpl
+++ b/views/templates/hook/displayBlockProduct.tpl
@@ -29,12 +29,20 @@
                     {/if}
                 {/if}&nbsp;
             </span>
-            {if empty($block['description'])}
-              <p class="block-title" style="color:{$textColor};">{$block['title']}</p>
-            {else}
-              <span class="block-title" style="color:{$textColor};">{$block['title']}</span>
-              <p style="color:{$textColor};">{$block['description'] nofilter}</p>
-            {/if}
+            <span class="block-title" style="color:{$textColor};">
+              {if empty($block['title'])}
+                &nbsp;
+              {else}
+                {$block['title']}
+              {/if}
+            </span>  
+            <p style="color:{$textColor};">
+              {if empty($block['description'])}
+                &nbsp;
+              {else}              
+                {$block['description'] nofilter}
+              {/if}
+            </p>
         </div>
     {/foreach}
     <div class="clearfix"></div>

--- a/views/templates/hook/displayBlockProduct.tpl
+++ b/views/templates/hook/displayBlockProduct.tpl
@@ -30,18 +30,10 @@
                 {/if}&nbsp;
             </span>
             <span class="block-title" style="color:{$textColor};">
-              {if empty($block['title'])}
-                &nbsp;
-              {else}
                 {$block['title']}
-              {/if}
             </span>  
             <p style="color:{$textColor};">
-              {if empty($block['description'])}
-                &nbsp;
-              {else}              
                 {$block['description'] nofilter}
-              {/if}
             </p>
         </div>
     {/foreach}


### PR DESCRIPTION
Problem: the current template code shows a **different** row structure from 3 default rows, in case a custom row's description is **empty**, that causes row misalignment as described in the related issue 28188.
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Solution: always add span-title and p-description, and fill with a space in case title and/or description empty to avoid row misalignment.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/28188
| How to test?  | Please follow the above issue's Steps to procedure Before and After PR.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
