### PR TITLE
Fix: non-svg custom icon is hidden in FO after editing in BO

### DIFF
--- a/controllers/admin/AdminBlockListingController.php
+++ b/controllers/admin/AdminBlockListingController.php
@@ -157,8 +157,11 @@ class AdminBlockListingController extends ModuleAdminController
             $blockPsr->status = false;
         }
         $blockPsr->handleBlockValues($psr_languages, $type_link, $id_cms);
-        $blockPsr->icon = $picto;
-        if (!empty($picto)) {
+        if (strpos($picto, $this->module->img_path_perso) !== false) {
+            $blockPsr->icon = '';
+            $blockPsr->custom_icon = $picto;
+        } else {
+            $blockPsr->icon = $picto;
             $blockPsr->custom_icon = '';
         }
         $blockPsr->date_add = date('Y-m-d H:i:s');


### PR DESCRIPTION
Problem: 
In **first** Upload and Save, the custom icon is stored in `custom_icon` column [AdminBlockListingController.php#L167-L204]( https://github.com/PrestaShop/blockreassurance/blob/dev/controllers/admin/AdminBlockListingController.php#L167-L204)
In **later** Edit and Save, the custom icon moved to `icon` column [AdminBlockListingController.php#L146-L163](https://github.com/PrestaShop/blockreassurance/blob/dev/controllers/admin/AdminBlockListingController.php#L146-L163)
So following [displayBlockProduct.tpl#L24-L30](https://github.com/PrestaShop/blockreassurance/blob/dev/views/templates/hook/displayBlockProduct.tpl#L24-L30), a **non-svg** custom icon is showed after **first** Save, then is hidden after **later** Save.
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Solution: <br> Predefined svg icon and Custom uploaded icon must be saved in `icon` and `custom_icon` column respectively, based on icon source.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop/issues/29134
| How to test?  | Please follow the related issue's Steps to reproduce before PR and after PR

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
