### PR TITLE
Fix: BO - Titles are not well displayed (overlap labels) with mobile

### DIFF
--- a/_dev/back/back.scss
+++ b/_dev/back/back.scss
@@ -302,6 +302,15 @@
     width: 35px;
 }
 
+@media (max-width:768px) {
+    .listing-row.row {
+        padding-top: 9px;
+    }
+    .listing-row div {
+        padding: 9px 0;
+    }
+}
+
 .inline-flex {
     display: inline-flex;
 }

--- a/_dev/back/back.scss
+++ b/_dev/back/back.scss
@@ -303,6 +303,20 @@
 }
 
 @media (max-width:768px) {
+    .listing-body {
+      .btn-group {        
+        .dropdown-menu {  
+          padding: 0.25rem 0;                  
+          min-width: 5.55rem;
+        }
+        .dropdown-item {
+          padding: .225rem .275rem;          
+          .material-icons {            
+            padding-right: .250rem;
+          }
+        }
+      }
+    }    
     .listing-row.row {
         padding-top: 0.5625rem;
     }

--- a/_dev/back/back.scss
+++ b/_dev/back/back.scss
@@ -304,19 +304,19 @@
 
 @media (max-width:768px) {
     .listing-body {
-      .btn-group {        
-        .dropdown-menu {  
-          padding: 0.25rem 0;                  
+      .btn-group {
+        .dropdown-menu {
+          padding: 0.25rem 0;
           min-width: 5.55rem;
         }
         .dropdown-item {
-          padding: .225rem .275rem;          
-          .material-icons {            
+          padding: .225rem .275rem;
+          .material-icons {
             padding-right: .250rem;
           }
         }
       }
-    }    
+    }
     .listing-row.row {
         padding-top: 0.5625rem;
     }

--- a/_dev/back/back.scss
+++ b/_dev/back/back.scss
@@ -304,10 +304,10 @@
 
 @media (max-width:768px) {
     .listing-row.row {
-        padding-top: 9px;
+        padding-top: 0.5625rem;
     }
     .listing-row div {
-        padding: 9px 0;
+        padding: 0.5625rem 0;
     }
 }
 

--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -279,7 +279,7 @@ class blockreassurance extends Module implements WidgetInterface
             'description' => $this->trans('Description', [], 'Modules.Blockreassurance.Admin'),
             'redirection' => $this->trans('Redirection', [], 'Modules.Blockreassurance.Admin'),
             'actions' => $this->trans('Actions', [], 'Modules.Blockreassurance.Admin'),
-        ];        
+        ];
 
         $this->context->smarty->assign([
             'psr_hook_header' => (int) Configuration::get('PSR_HOOK_HEADER'),

--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -271,7 +271,6 @@ class blockreassurance extends Module implements WidgetInterface
         $moduleAdminLink = Context::getContext()->link->getAdminLink('AdminModules', true) . '&configure=' . $this->name . '&module_name=' . $this->name;
 
         $allCms = CMS::listCms($id_lang);
-        
         $fields_captions = [
             'position' => $this->trans('Position', [], 'Modules.Blockreassurance.Admin'),
             'image' => $this->trans('Image', [], 'Modules.Blockreassurance.Admin'),

--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -271,6 +271,15 @@ class blockreassurance extends Module implements WidgetInterface
         $moduleAdminLink = Context::getContext()->link->getAdminLink('AdminModules', true) . '&configure=' . $this->name . '&module_name=' . $this->name;
 
         $allCms = CMS::listCms($id_lang);
+        
+        $fields_captions = [
+            'position' => $this->trans('Position', [], 'Modules.Blockreassurance.Admin'),
+            'image' => $this->trans('Image', [], 'Modules.Blockreassurance.Admin'),
+            'title' => $this->trans('Title', [], 'Modules.Blockreassurance.Admin'),
+            'description' => $this->trans('Description', [], 'Modules.Blockreassurance.Admin'),
+            'redirection' => $this->trans('Redirection', [], 'Modules.Blockreassurance.Admin'),
+            'actions' => $this->trans('Actions', [], 'Modules.Blockreassurance.Admin'),
+        ];        
 
         $this->context->smarty->assign([
             'psr_hook_header' => (int) Configuration::get('PSR_HOOK_HEADER'),
@@ -295,6 +304,7 @@ class blockreassurance extends Module implements WidgetInterface
             'LINK_TYPE_NONE' => ReassuranceActivity::TYPE_LINK_NONE,
             'LINK_TYPE_CMS' => ReassuranceActivity::TYPE_LINK_CMS_PAGE,
             'LINK_TYPE_URL' => ReassuranceActivity::TYPE_LINK_URL,
+            'fields_captions' => $fields_captions,
         ]);
 
         return $this->display(__FILE__, 'views/templates/admin/configure.tpl');

--- a/views/templates/admin/tabs/content/listing.tpl
+++ b/views/templates/admin/tabs/content/listing.tpl
@@ -37,13 +37,13 @@
                     {foreach from=$allblock item=$block key=$key}
                         <div class="listing-general-rol row" data-block="{$block.id_psreassurance}">
                             <div class="listing-row row">
-			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                <div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.position}
                                 </div>
                                 <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6">
                                     <i class="material-icons">drag_indicator</i>
                                 </div>
-			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                <div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.image}
                                 </div>                                
                                 <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6">
@@ -55,7 +55,7 @@
                                         {l s='none' d='Modules.Blockreassurance.Admin'}
                                     {/if}
                                 </div>
-			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                <div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.title}
                                 </div>                                
                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
@@ -67,7 +67,7 @@
                                 <div class="col-lg-4 col-md-4 col-sm-4 col-xs-6">
                                     {$block['description'][{$defaultFormLanguage}]}
                                 </div>
-			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                <div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.redirection}
                                 </div>                                
                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
@@ -79,7 +79,7 @@
                                         {l s='CMS Page' d='Modules.Blockreassurance.Admin'}
                                     {/if}
                                 </div>
-			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                <div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.actions}
                                 </div>                                
                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6 inline-flex">

--- a/views/templates/admin/tabs/content/listing.tpl
+++ b/views/templates/admin/tabs/content/listing.tpl
@@ -37,13 +37,13 @@
                     {foreach from=$allblock item=$block key=$key}
                         <div class="listing-general-rol row" data-block="{$block.id_psreassurance}">
                             <div class="listing-row row">
-								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.position}
                                 </div>
                                 <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6">
                                     <i class="material-icons">drag_indicator</i>
                                 </div>
-								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.image}
                                 </div>                                
                                 <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6">
@@ -55,19 +55,19 @@
                                         {l s='none' d='Modules.Blockreassurance.Admin'}
                                     {/if}
                                 </div>
-								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.title}
                                 </div>                                
                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
                                     {$block['title'][{$defaultFormLanguage}]}
                                 </div>
-								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.description}
                                 </div>                                
                                 <div class="col-lg-4 col-md-4 col-sm-4 col-xs-6">
                                     {$block['description'][{$defaultFormLanguage}]}
                                 </div>
-								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.redirection}
                                 </div>                                
                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
@@ -79,7 +79,7 @@
                                         {l s='CMS Page' d='Modules.Blockreassurance.Admin'}
                                     {/if}
                                 </div>
-								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.actions}
                                 </div>                                
                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6 inline-flex">

--- a/views/templates/admin/tabs/content/listing.tpl
+++ b/views/templates/admin/tabs/content/listing.tpl
@@ -61,7 +61,7 @@
                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xs-8">
                                     {$block['title'][{$defaultFormLanguage}]}
                                 </div>
-			        <div class="hidden-lg hidden-md hidden-sm col-xs-4">
+                                <div class="hidden-lg hidden-md hidden-sm col-xs-4">
                                     {$fields_captions.description}
                                 </div>                                
                                 <div class="col-lg-4 col-md-4 col-sm-4 col-xs-8">

--- a/views/templates/admin/tabs/content/listing.tpl
+++ b/views/templates/admin/tabs/content/listing.tpl
@@ -37,13 +37,13 @@
                     {foreach from=$allblock item=$block key=$key}
                         <div class="listing-general-rol row" data-block="{$block.id_psreassurance}">
                             <div class="listing-row row">
-				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.position}
                                 </div>
                                 <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6">
                                     <i class="material-icons">drag_indicator</i>
                                 </div>
-				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.image}
                                 </div>                                
                                 <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6">
@@ -55,19 +55,19 @@
                                         {l s='none' d='Modules.Blockreassurance.Admin'}
                                     {/if}
                                 </div>
-				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.title}
                                 </div>                                
                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
                                     {$block['title'][{$defaultFormLanguage}]}
                                 </div>
-				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.description}
                                 </div>                                
                                 <div class="col-lg-4 col-md-4 col-sm-4 col-xs-6">
                                     {$block['description'][{$defaultFormLanguage}]}
                                 </div>
-				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.redirection}
                                 </div>                                
                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
@@ -79,7 +79,7 @@
                                         {l s='CMS Page' d='Modules.Blockreassurance.Admin'}
                                     {/if}
                                 </div>
-				<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
                                     {$fields_captions.actions}
                                 </div>                                
                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6 inline-flex">

--- a/views/templates/admin/tabs/content/listing.tpl
+++ b/views/templates/admin/tabs/content/listing.tpl
@@ -37,16 +37,16 @@
                     {foreach from=$allblock item=$block key=$key}
                         <div class="listing-general-rol row" data-block="{$block.id_psreassurance}">
                             <div class="listing-row row">
-                                <div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                <div class="hidden-lg hidden-md hidden-sm col-xs-4">
                                     {$fields_captions.position}
                                 </div>
-                                <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6">
+                                <div class="col-lg-1 col-md-1 col-sm-1 col-xs-8">
                                     <i class="material-icons">drag_indicator</i>
                                 </div>
-                                <div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                <div class="hidden-lg hidden-md hidden-sm col-xs-4">
                                     {$fields_captions.image}
                                 </div>                                
-                                <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6">
+                                <div class="col-lg-1 col-md-1 col-sm-1 col-xs-8">
                                     {if $block['icon'] != 'undefined'}
                                         <img class="svg"
                                              src="{if $block['icon']}{$block['icon']}{else if $block['custom_icon']}{$block['custom_icon']}{/if}"
@@ -55,22 +55,22 @@
                                         {l s='none' d='Modules.Blockreassurance.Admin'}
                                     {/if}
                                 </div>
-                                <div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                <div class="hidden-lg hidden-md hidden-sm col-xs-4">
                                     {$fields_captions.title}
                                 </div>                                
-                                <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
+                                <div class="col-lg-2 col-md-2 col-sm-2 col-xs-8">
                                     {$block['title'][{$defaultFormLanguage}]}
                                 </div>
-			        <div class="hidden-lg hidden-md hidden-sm col-xs-6">
+			        <div class="hidden-lg hidden-md hidden-sm col-xs-4">
                                     {$fields_captions.description}
                                 </div>                                
-                                <div class="col-lg-4 col-md-4 col-sm-4 col-xs-6">
+                                <div class="col-lg-4 col-md-4 col-sm-4 col-xs-8">
                                     {$block['description'][{$defaultFormLanguage}]}
                                 </div>
-                                <div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                <div class="hidden-lg hidden-md hidden-sm col-xs-4">
                                     {$fields_captions.redirection}
                                 </div>                                
-                                <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
+                                <div class="col-lg-2 col-md-2 col-sm-2 col-xs-8">
                                     {if $block['type_link'] == $LINK_TYPE_NONE}
                                         {l s='None' d='Modules.Blockreassurance.Admin'}
                                     {elseif $block['type_link'] == $LINK_TYPE_URL}
@@ -79,10 +79,10 @@
                                         {l s='CMS Page' d='Modules.Blockreassurance.Admin'}
                                     {/if}
                                 </div>
-                                <div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                <div class="hidden-lg hidden-md hidden-sm col-xs-4">
                                     {$fields_captions.actions}
                                 </div>                                
-                                <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6 inline-flex">
+                                <div class="col-lg-2 col-md-2 col-sm-2 col-xs-8 inline-flex">
                                     <label class="col-lg-12 col-xs-12 status-toggle"
                                            id="reminder_active_{$block['id_psreassurance']}"
                                            for="reminder_active_{$block['id_psreassurance']}"

--- a/views/templates/admin/tabs/content/listing.tpl
+++ b/views/templates/admin/tabs/content/listing.tpl
@@ -26,12 +26,12 @@
         <div class="clearfix">
             <div class="listing-table col-xs-12">
                 <div class="listing-head row">
-                    <div class="col-xs-1 content-header">{l s='Position' d='Modules.Blockreassurance.Admin'}</div>
-                    <div class="col-xs-1 content-header">{l s='Image' d='Modules.Blockreassurance.Admin'}</div>
-                    <div class="col-xs-2 content-header">{l s='Title' d='Modules.Blockreassurance.Admin'}</div>
-                    <div class="col-xs-4 content-header">{l s='Description' d='Modules.Blockreassurance.Admin'}</div>
-                    <div class="col-xs-2 content-header">{l s='Redirection' d='Modules.Blockreassurance.Admin'}</div>
-                    <div class="col-xs-2 content-header">{l s='Actions' d='Modules.Blockreassurance.Admin'}</div>
+                    <div class="col-lg-1 col-md-1 col-sm-1 hidden-xs content-header">{$fields_captions.position}</div>
+                    <div class="col-lg-1 col-md-1 col-sm-1 hidden-xs content-header">{$fields_captions.image}</div>
+                    <div class="col-lg-2 col-md-2 col-sm-2 hidden-xs content-header">{$fields_captions.title}</div>
+                    <div class="col-lg-4 col-md-4 col-sm-4 hidden-xs content-header">{$fields_captions.description}</div>
+                    <div class="col-lg-2 col-md-2 col-sm-2 hidden-xs content-header">{$fields_captions.redirection}</div>
+                    <div class="col-lg-2 col-md-2 col-sm-2 hidden-xs content-header">{$fields_captions.actions}</div>
                 </div>
                 <div class="listing-body col-lg-12  col-xs-12">
                     {foreach from=$allblock item=$block key=$key}

--- a/views/templates/admin/tabs/content/listing.tpl
+++ b/views/templates/admin/tabs/content/listing.tpl
@@ -37,10 +37,16 @@
                     {foreach from=$allblock item=$block key=$key}
                         <div class="listing-general-rol row" data-block="{$block.id_psreassurance}">
                             <div class="listing-row row">
-                                <div class="col-xs-1">
+								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                    {$fields_captions.position}
+                                </div>
+                                <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6">
                                     <i class="material-icons">drag_indicator</i>
                                 </div>
-                                <div class="col-xs-1">
+								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                    {$fields_captions.image}
+                                </div>                                
+                                <div class="col-lg-1 col-md-1 col-sm-1 col-xs-6">
                                     {if $block['icon'] != 'undefined'}
                                         <img class="svg"
                                              src="{if $block['icon']}{$block['icon']}{else if $block['custom_icon']}{$block['custom_icon']}{/if}"
@@ -49,13 +55,22 @@
                                         {l s='none' d='Modules.Blockreassurance.Admin'}
                                     {/if}
                                 </div>
-                                <div class="col-xs-2">
+								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                    {$fields_captions.title}
+                                </div>                                
+                                <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
                                     {$block['title'][{$defaultFormLanguage}]}
                                 </div>
-                                <div class="col-xs-4">
+								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                    {$fields_captions.description}
+                                </div>                                
+                                <div class="col-lg-4 col-md-4 col-sm-4 col-xs-6">
                                     {$block['description'][{$defaultFormLanguage}]}
                                 </div>
-                                <div class="col-xs-2">
+								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                    {$fields_captions.redirection}
+                                </div>                                
+                                <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6">
                                     {if $block['type_link'] == $LINK_TYPE_NONE}
                                         {l s='None' d='Modules.Blockreassurance.Admin'}
                                     {elseif $block['type_link'] == $LINK_TYPE_URL}
@@ -64,7 +79,10 @@
                                         {l s='CMS Page' d='Modules.Blockreassurance.Admin'}
                                     {/if}
                                 </div>
-                                <div class="col-xs-2 inline-flex">
+								<div class="hidden-lg hidden-md hidden-sm col-xs-6">
+                                    {$fields_captions.actions}
+                                </div>                                
+                                <div class="col-lg-2 col-md-2 col-sm-2 col-xs-6 inline-flex">
                                     <label class="col-lg-12 col-xs-12 status-toggle"
                                            id="reminder_active_{$block['id_psreassurance']}"
                                            for="reminder_active_{$block['id_psreassurance']}"
@@ -86,7 +104,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="col-lg-12 col-xs-12">
+                            <div class="col-lg-12 col-sm-12 col-xs-12">
                                 <div id="_more_info" class="col-lg-12 more_info ajax_return"></div>
                             </div>
                         </div>


### PR DESCRIPTION
Problem: listing in BO blockreassurance / configure / tabs / content is not rendered by `HelperList` so it does not support mobile view well.
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Solution: Hide listing's Top captions in mobile view and Show listing's Inline captions in mobile view <br> Note: assign values of 6 `$this->trans('xyz phrase', [], 'Modules.Blockreassurance.Admin')` to an array in .php to avoid repeating these long `trans` in .tpl file; there are other format issues in the module config form in mobile view but it is out of scope of this PR.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [Issue 28064](https://github.com/PrestaShop/PrestaShop/issues/28064)
| How to test?  | Please the above issue's Steps to reproduce before PR and after PR. (below is how the module configure > content listing looks in mobile view portrait mode after PR)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
![blockreassuracne_BO_mobile_potrait_IPhoneSE](https://user-images.githubusercontent.com/3759923/182017056-24392d9b-6124-4182-8827-a19845f33273.png)
