### PR TITLE
Add link when used as a widget

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -453,8 +453,6 @@ class blockreassurance extends Module implements WidgetInterface
         return [
             'elements' => $elements,
             'LINK_TYPE_NONE' => ReassuranceActivity::TYPE_LINK_NONE,
-            'LINK_TYPE_CMS' => ReassuranceActivity::TYPE_LINK_CMS_PAGE,
-            'LINK_TYPE_URL' => ReassuranceActivity::TYPE_LINK_URL,
         ];
     }
 

--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -446,10 +446,15 @@ class blockreassurance extends Module implements WidgetInterface
             $elements[$key]['text'] = $value['title'] . ' ' . $value['description'];
             $elements[$key]['title'] = $value['title'];
             $elements[$key]['description'] = $value['description'];
+            $elements[$key]['type_link'] = $value['type_link'];
+            $elements[$key]['link'] = $value['link'];
         }
 
         return [
             'elements' => $elements,
+            'LINK_TYPE_NONE' => ReassuranceActivity::TYPE_LINK_NONE,
+            'LINK_TYPE_CMS' => ReassuranceActivity::TYPE_LINK_CMS_PAGE,
+            'LINK_TYPE_URL' => ReassuranceActivity::TYPE_LINK_URL,
         ];
     }
 

--- a/views/templates/hook/blockreassurance.tpl
+++ b/views/templates/hook/blockreassurance.tpl
@@ -20,7 +20,12 @@
     <div id="block-reassurance">
         <ul>
             {foreach from=$elements item=element}
-                <li><img src="{$element.image}" alt="{$element.text|escape:'quotes'}"/> <span>{$element.text}</span></li>
+                <li>
+                    <div class="block-reassurance-item" {if $element['type_link'] !== $LINK_TYPE_NONE && !empty($element['link'])} style="cursor:pointer;" onclick="window.open('{$element['link']}')"{/if}>
+                        <img src="{$element.image}" alt="{$element.text|escape:'quotes'}"/>
+                        <span>{$element.text}</span>
+                    </div>
+                </li>
             {/foreach}
         </ul>
     </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | [function getWidgetVariables](https://github.com/PrestaShop/blockreassurance/blob/dev/blockreassurance.php#L430-L454) does not return block's link, then [function renderWidget](https://github.com/PrestaShop/blockreassurance/blob/dev/blockreassurance.php#L411) does not show block's link when the modules is used as a widget
| Type?         | improvement
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/21752
| How to test? | Here are steps to test with classic-theme: <br>- Apply the PR changes <br>- **Rename** `blockreassurance.tpl` in [classic-theme](https://github.com/PrestaShop/classic-theme/tree/develop/modules/blockreassurance/views/templates/hook) folder to other (`block_hook_reassurance.tpl` e.g) to force using the module's widget template file instead. <br>- Put this widget code `{widget name='blockreassurance'}` somewhere in [category-footer.tpl](https://github.com/PrestaShop/classic-theme/blob/develop/templates/catalog/_partials/category-footer.tpl) (at line 25 e.g)<br>- In BO: Adv. Parameters > Performance > Clear cache to force using new template; set at least a link for a block in module's Config content<br>- In FO: open a category page to see the widget with block's link in the bottom of page. <br>_(Here are steps for a quick test, in fact, you need to copy new code from the module widget template to the theme override template appropriately :)_

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
