### PR TITLE
Stop using javascript window.open in template

### DIFF
--- a/views/templates/hook/displayBlock.tpl
+++ b/views/templates/hook/displayBlock.tpl
@@ -44,8 +44,8 @@
                     {assign var=sizeCol_sm value=(12 / $numColsRemaining_md)}
                 {/if}
             {/if}
-            <div class="col-md-{$sizeCol_md} {$offsetCol_md} col-sm-{$sizeCol_sm} {$offsetCol_sm} col-xs-12"
-                {if $block['type_link'] !== $LINK_TYPE_NONE && !empty($block['link'])} style="cursor:pointer;" onclick="window.open('{$block['link']}')"{/if}>
+            <div class="col-md-{$sizeCol_md} {$offsetCol_md} col-sm-{$sizeCol_sm} {$offsetCol_sm} col-xs-12">
+                {if $block['type_link'] !== $LINK_TYPE_NONE && !empty($block['link'])} <a href="{$block['link']}" target="_blank"> {/if}
                 <div class="block-icon">
                     {if $block['icon'] != 'undefined'}
                         {if $block['custom_icon']}
@@ -57,6 +57,7 @@
                 </div>
                 <div class="block-title" style="color:{$textColor}">{$block['title']}</div>
                 <p style="color:{$textColor};">{$block['description'] nofilter}</p>
+                {if $block['type_link'] !== $LINK_TYPE_NONE && !empty($block['link'])} </a> {/if}
             </div>
             {if $idxCol % 4 == 0}</div><div class="row">{/if}
         {/foreach}

--- a/views/templates/hook/displayBlockProduct.tpl
+++ b/views/templates/hook/displayBlockProduct.tpl
@@ -19,7 +19,8 @@
 
 <div class="blockreassurance_product">
     {foreach from=$blocks item=$block key=$key}
-        <div{if $block['type_link'] !== $LINK_TYPE_NONE && !empty($block['link'])} style="cursor:pointer;" onclick="window.open('{$block['link']}')"{/if}>
+        <div>
+        {if $block['type_link'] !== $LINK_TYPE_NONE && !empty($block['link'])} <a href="{$block['link']}" target="_blank"> {/if}
             <span class="item-product">
                 {if $block['icon'] != 'undefined'}
                     {if $block['custom_icon']}
@@ -35,6 +36,7 @@
               <span class="block-title" style="color:{$textColor};">{$block['title']}</span>
               <p style="color:{$textColor};">{$block['description'] nofilter}</p>
             {/if}
+        {if $block['type_link'] !== $LINK_TYPE_NONE && !empty($block['link'])} </a> {/if}
         </div>
     {/foreach}
     <div class="clearfix"></div>

--- a/views/templates/hook/displayBlockWhite.tpl
+++ b/views/templates/hook/displayBlockWhite.tpl
@@ -43,8 +43,8 @@
                 {assign var=sizeCol_sm value=(12 / $numColsRemaining_md)}
             {/if}
         {/if}
-        <div class="col-md-{$sizeCol_md} {$offsetCol_md} col-sm-{$sizeCol_sm} {$offsetCol_sm} col-xs-12"
-            {if $block['type_link'] !== $LINK_TYPE_NONE && !empty($block['link'])} style="cursor:pointer;" onclick="window.open('{$block['link']}')"{/if}>
+        <div class="col-md-{$sizeCol_md} {$offsetCol_md} col-sm-{$sizeCol_sm} {$offsetCol_sm} col-xs-12">
+        {if $block['type_link'] !== $LINK_TYPE_NONE && !empty($block['link'])} <a href="{$block['link']}" target="_blank"> {/if}
             <div class="block-icon">
                 {if $block['icon'] != 'undefined'}
                     {if $block['custom_icon']}
@@ -56,6 +56,7 @@
             </div>
             <div class="block-title" style="color:{$textColor}">{$block['title']}</div>
             <p style="color:{$textColor};">{$block['description'] nofilter}</p>
+        {if $block['type_link'] !== $LINK_TYPE_NONE && !empty($block['link'])} </a> {/if}
         </div>
       {if $idxCol % 4 == 0}</div><div class="row">{/if}
     {/foreach}


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Three templates in module blockreassurance [displayBlock.tpl](https://github.com/PrestaShop/blockreassurance/blob/dev/views/templates/hook/displayBlock.tpl#L48), [displayBlockProduct.tpl](https://github.com/PrestaShop/blockreassurance/blob/dev/views/templates/hook/displayBlock.tpl#L48), [displayBlockWhite.tpl](https://github.com/PrestaShop/blockreassurance/blob/dev/views/templates/hook/displayBlockWhite.tpl#L47) are using JavaScript `window.open` method to emulate a link. <br> We don't have any validation with links there so replace the JavaScript `window.open` by a pure HTML `a` tag will be better.
| Type?         | improvement
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | [Issue 30055](https://github.com/PrestaShop/PrestaShop/issues/30055).
| How to test?  | After applying PR, check blockreassurance block on Product page to make sure the block view and link work as usual.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
