### PR TITLE
Remove unused jqueryColorPicker plugin

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -235,7 +235,7 @@ class blockreassurance extends Module implements WidgetInterface
         $this->addJsDefList();
 
         $this->context->controller->addCSS($this->_path . 'views/dist/back.css', 'all');
-        $this->context->controller->addJS($this->_path . 'views/dist/back.js');        
+        $this->context->controller->addJS($this->_path . 'views/dist/back.js');
         $this->context->controller->addJqueryUI('ui.sortable');
     }
 

--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -235,8 +235,7 @@ class blockreassurance extends Module implements WidgetInterface
         $this->addJsDefList();
 
         $this->context->controller->addCSS($this->_path . 'views/dist/back.css', 'all');
-        $this->context->controller->addJS($this->_path . 'views/dist/back.js');
-        $this->context->controller->addJqueryPlugin('colorpicker');
+        $this->context->controller->addJS($this->_path . 'views/dist/back.js');        
         $this->context->controller->addJqueryUI('ui.sortable');
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | blockreassurance's ColorPicker uses `@simonwep/pickr`, not jquery ColorPicker plugin as written at <br> [_dev/back/index.js#L19](https://github.com/PrestaShop/blockreassurance/blob/dev/_dev/back/index.js#L19) and [_dev/back/index.js#L492-L537](https://github.com/PrestaShop/blockreassurance/blob/dev/_dev/back/index.js#L492-L537)
| Type?         | improvement
| BC breaks?    | Does it break backward compatibility? no
| Deprecations? | Does it deprecate an existing feature? no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/27186 (partly). Related to [ps_facetedsearch/pull/691](https://github.com/PrestaShop/ps_facetedsearch/pull/691)
| How to test?  | After apply this PR, check ColorPicker in the module BO Config's Appearance to make sure the colors can be selected and saved there, then showed in FO as usual.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
