### PR TITLE
Use proper category front_office_features

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -88,7 +88,7 @@ class blockreassurance extends Module implements WidgetInterface
     {
         // Settings
         $this->name = 'blockreassurance';
-        $this->tab = 'seo';
+        $this->tab = 'front_office_features';
         $this->version = '5.1.1';
         $this->author = 'PrestaShop';
         $this->need_instance = false;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This module should be in front_office_features category as all other frontend modules. There is no reason this module should be listed in seo category. Also, as this is a native classic theme module, it will be listed in in `Theme modules` section anyway.
| Type?         | bug fix
| BC breaks?    | 
| Deprecations? | 
| Fixed ticket? | 
| How to test?  | 
