### PR TITLE
Fix folder is_executable check on windows platform

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -245,8 +245,15 @@ class blockreassurance extends Module implements WidgetInterface
      */
     private function folderUploadFilesHasGoodRights()
     {
-        return is_writable($this->folder_file_upload)
-            && is_executable($this->folder_file_upload);
+        if (is_writable($this->folder_file_upload))
+        {
+            if (preg_match('/^[a-zA-Z]{1}\:{1}\\\\{1}/', $this->folder_file_upload) !== 1)    // do not check is_executable on windows platform - always false
+            {
+                return is_executable($this->folder_file_upload);
+            }
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -245,15 +245,8 @@ class blockreassurance extends Module implements WidgetInterface
      */
     private function folderUploadFilesHasGoodRights()
     {
-        if (is_writable($this->folder_file_upload)) {
-            if (preg_match('/^[a-zA-Z]{1}\:{1}\\\\{1}/', $this->folder_file_upload) !== 1) {    // do not check is_executable on windows platform - always false
-                return is_executable($this->folder_file_upload);
-            }
-
-            return true;
-        }
-
-        return false;
+        // do not check is_executable on windows platform (https://www.php.net/manual/en/function.is-executable.php#refsect1-function.is-executable-notes)
+        return is_writable($this->folder_file_upload) && !(preg_match('/^[a-zA-Z]{1}\:{1}\\\\{1}/', $this->folder_file_upload) !== 1) || is_executable($this->folder_file_upload;
     }
 
     /**

--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -245,14 +245,14 @@ class blockreassurance extends Module implements WidgetInterface
      */
     private function folderUploadFilesHasGoodRights()
     {
-        if (is_writable($this->folder_file_upload))
-        {
-            if (preg_match('/^[a-zA-Z]{1}\:{1}\\\\{1}/', $this->folder_file_upload) !== 1)    // do not check is_executable on windows platform - always false
-            {
+        if (is_writable($this->folder_file_upload)) {
+            if (preg_match('/^[a-zA-Z]{1}\:{1}\\\\{1}/', $this->folder_file_upload) !== 1) {    // do not check is_executable on windows platform - always false
                 return is_executable($this->folder_file_upload);
             }
+
             return true;
         }
+
         return false;
     }
 

--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -246,7 +246,7 @@ class blockreassurance extends Module implements WidgetInterface
     private function folderUploadFilesHasGoodRights()
     {
         // do not check is_executable on windows platform (https://www.php.net/manual/en/function.is-executable.php#refsect1-function.is-executable-notes)
-        return is_writable($this->folder_file_upload) && !(preg_match('/^[a-zA-Z]{1}\:{1}\\\\{1}/', $this->folder_file_upload) !== 1) || is_executable($this->folder_file_upload;
+        return is_writable($this->folder_file_upload) && !(preg_match('/^[a-zA-Z]{1}\:{1}\\\\{1}/', $this->folder_file_upload) !== 1) || is_executable($this->folder_file_upload);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | On the windows platform is_executable() always return false for folders. It only returns true on windows files with the extensions .bat or .exe.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Check that you can still upload images. For devs: Passing linux file path by $this->folder_file_upload variable should execute is_executable() call. Passing windows file path (with the drive label at begin (like "C:\" )) skips this call.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
