### PR TITLE
Update github actions' checkout and cache to v3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v3.0.0
 
       - name: PHP syntax checker 5.6
         uses: prestashop/github-action-php-lint/5.6@master
@@ -38,10 +38,10 @@ jobs:
           php-version: '7.4'
 
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v3.0.0
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
@@ -66,18 +66,18 @@ jobs:
           php-version: '7.4'
 
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v3.0.0
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3.1.0
 
       - name: PHP syntax checker 5.6
         uses: prestashop/github-action-php-lint/5.6@master
@@ -38,7 +38,7 @@ jobs:
           php-version: '7.4'
 
       - name: Checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3.1.0
 
       - name: Cache dependencies
         uses: actions/cache@v3
@@ -66,7 +66,7 @@ jobs:
           php-version: '7.4'
 
       - name: Checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3.1.0
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Update to solve deprecated warning of PHP tests
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | [Issue](https://github.com/PrestaShop/PrestaShop/issues), please write "Fixes #[issue number]" here.
| How to test?  | PHP test run successfully without warning about deprecated github actions' checkout and cache

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
