### PR TITLE
Keep both old saved and new chose SVG icons above Material icon

### DIFF
--- a/views/templates/admin/tabs/content/config_elements/icon.tpl
+++ b/views/templates/admin/tabs/content/config_elements/icon.tpl
@@ -29,11 +29,11 @@
         <div class="psr_picto_showing input-group col-lg-4">
             <img class="psr-picto picto_by_module svg"
                  src="{if isset($block) && $block['icon']}{$block['icon']}{elseif isset($block) && $block['custom_icon']}{$block['custom_icon']}{/if}"/>
-            <div>
-                <i class="material-icons">landscape</i>
-            </div>
             <div class="svg_chosed_here">
                 <img class="image-preview-lang img-thumbnail hide" src="" alt="" width="24px" height="24px"/>
+            </div>
+            <div>
+                <i class="material-icons">landscape</i>
             </div>
             <span class="modify_icon" data-id="{if isset($block)}{$block['id_psreassurance']}{/if}">{l s='Modify icon' d='Modules.Blockreassurance.Admin'}</span>
         </div>


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Before #518, in Modify icon modal, landscape icon was hidden so we didn't recognize it is between Old saved and New chose SVG icons. <br>This PR move Material icon landscape to under both Old saved and New chose SVG icons, then we won't see it move up and down any more. 
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes [#538 review ](https://github.com/PrestaShop/blockreassurance/pull/538#pullrequestreview-1431004412)
| How to test?  | Both old saved and new chose SVG icons above Material icon after applied this PR.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
