### PR TITLE
Feature: Multistore list block

### DIFF
--- a/classes/ReassuranceActivity.php
+++ b/classes/ReassuranceActivity.php
@@ -150,7 +150,7 @@ class ReassuranceActivity extends ObjectModel
      */
     public static function getAllBlockByStatus($id_lang = 1)
     {
-        $id_shop = (int)Context::getContext()->shop->id;
+        $id_shop = (int) Context::getContext()->shop->id;
 
         $sql = 'SELECT * FROM `' . _DB_PREFIX_ . 'psreassurance` pr
             LEFT JOIN ' . _DB_PREFIX_ . 'psreassurance_lang prl ON (pr.id_psreassurance = prl.id_psreassurance)

--- a/classes/ReassuranceActivity.php
+++ b/classes/ReassuranceActivity.php
@@ -150,9 +150,12 @@ class ReassuranceActivity extends ObjectModel
      */
     public static function getAllBlockByStatus($id_lang = 1)
     {
+        $id_shop = (int)Context::getContext()->shop->id;
+
         $sql = 'SELECT * FROM `' . _DB_PREFIX_ . 'psreassurance` pr
             LEFT JOIN ' . _DB_PREFIX_ . 'psreassurance_lang prl ON (pr.id_psreassurance = prl.id_psreassurance)
             WHERE prl.id_lang = "' . (int) $id_lang . '"
+                AND prl.id_shop = "' . (int) $id_shop . '"
                 AND pr.status = 1
             ORDER BY pr.position';
 


### PR DESCRIPTION
Add id_shop for multishop purpouse

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing this change. What did you change? Why?
| Type?             | bug fix / improvement 
| BC breaks?        | yes / no - propably yes but need investgation
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/29219
| Sponsor company   | Webo.agency
| How to test?      | Enable multistore. Add block for one store. Change store and add another block with same language. Have different text for different store in same language. Check homepage - should display all blocks and don't have difference in context of choosen shop. Apply this pull-request - see fever blocks that exist only in one id_shop context which is what you expect
