### PR TITLE
Migrate ObjectModel to Doctrine

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: PHP syntax checker 7.1
-        uses: prestashop/github-action-php-lint/5.6@master
+        uses: prestashop/github-action-php-lint/7.1@master
 
       - name: PHP syntax checker 7.2
         uses: prestashop/github-action-php-lint/7.2@master

--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -26,6 +26,7 @@ if (file_exists($autoloadPath)) {
     require_once $autoloadPath;
 }
 
+use PrestaShop\Module\BlockReassurance\Entity\Psreassurance;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
 class blockreassurance extends Module implements WidgetInterface
@@ -273,6 +274,8 @@ class blockreassurance extends Module implements WidgetInterface
 
         $moduleAdminLink = Context::getContext()->link->getAdminLink('AdminModules', true) . '&configure=' . $this->name . '&module_name=' . $this->name;
 
+        $reassuranceRepository = $this->get('block_reassurance_repository');
+
         $allCms = CMS::listCms($id_lang);
         $fields_captions = [
             'position' => $this->trans('Position', [], 'Modules.Blockreassurance.Admin'),
@@ -292,7 +295,7 @@ class blockreassurance extends Module implements WidgetInterface
             'psr_icon_color' => Configuration::get('PSR_ICON_COLOR'),
             'logo_path' => $this->logo_path,
             'languages' => Language::getLanguages(false),
-            'allblock' => ReassuranceActivity::getAllBlock(),
+            'allblock' => $reassuranceRepository->getAllBlock(),
             'currentPage' => $currentPage,
             'moduleAdminLink' => $moduleAdminLink,
             'img_path' => $this->img_path,
@@ -303,9 +306,9 @@ class blockreassurance extends Module implements WidgetInterface
             'folderIsWritable' => $this->folderUploadFilesHasGoodRights(),
             'folderPath' => $this->img_path_perso,
             // constants
-            'LINK_TYPE_NONE' => ReassuranceActivity::TYPE_LINK_NONE,
-            'LINK_TYPE_CMS' => ReassuranceActivity::TYPE_LINK_CMS_PAGE,
-            'LINK_TYPE_URL' => ReassuranceActivity::TYPE_LINK_URL,
+            'LINK_TYPE_NONE' => Psreassurance::TYPE_LINK_NONE,
+            'LINK_TYPE_CMS' => Psreassurance::TYPE_LINK_CMS_PAGE,
+            'LINK_TYPE_URL' => Psreassurance::TYPE_LINK_URL,
             'fields_captions' => $fields_captions,
         ]);
 
@@ -432,7 +435,8 @@ class blockreassurance extends Module implements WidgetInterface
      */
     public function getWidgetVariables($hookName = null, array $configuration = [])
     {
-        $blocks = ReassuranceActivity::getAllBlockByStatus(
+        $reassuranceRepository = $this->get('block_reassurance_repository');
+        $blocks = $reassuranceRepository->getAllBlockByStatus(
             $this->context->language->id
         );
 
@@ -455,7 +459,7 @@ class blockreassurance extends Module implements WidgetInterface
 
         return [
             'elements' => $elements,
-            'LINK_TYPE_NONE' => ReassuranceActivity::TYPE_LINK_NONE,
+            'LINK_TYPE_NONE' => Psreassurance::TYPE_LINK_NONE,
         ];
     }
 
@@ -492,16 +496,17 @@ class blockreassurance extends Module implements WidgetInterface
      */
     private function renderTemplateInHook($template)
     {
+        $reassuranceRepository = $this->get('block_reassurance_repository');
         $id_lang = $this->context->language->id;
 
         $this->context->smarty->assign([
-            'blocks' => ReassuranceActivity::getAllBlockByStatus($id_lang),
+            'blocks' => $reassuranceRepository->getAllBlockByStatus($id_lang),
             'iconColor' => Configuration::get('PSR_ICON_COLOR'),
             'textColor' => Configuration::get('PSR_TEXT_COLOR'),
             // constants
-            'LINK_TYPE_NONE' => ReassuranceActivity::TYPE_LINK_NONE,
-            'LINK_TYPE_CMS' => ReassuranceActivity::TYPE_LINK_CMS_PAGE,
-            'LINK_TYPE_URL' => ReassuranceActivity::TYPE_LINK_URL,
+            'LINK_TYPE_NONE' => Psreassurance::TYPE_LINK_NONE,
+            'LINK_TYPE_CMS' => Psreassurance::TYPE_LINK_CMS_PAGE,
+            'LINK_TYPE_URL' => Psreassurance::TYPE_LINK_URL,
         ]);
 
         return $this->display(__FILE__, 'views/templates/hook/' . $template);

--- a/classes/ReassuranceActivity.php
+++ b/classes/ReassuranceActivity.php
@@ -176,7 +176,7 @@ class ReassuranceActivity extends ObjectModel
     /**
      * @return string|bool
      *
-     * @deprecated since 6.0.0 - migrated to ImageManager since PS 1.7.7.0
+     * @deprecated 6.0.0 - migrated to ImageManager since PS 1.7.7.0
      */
     public static function getMimeType(string $filename)
     {

--- a/classes/ReassuranceActivity.php
+++ b/classes/ReassuranceActivity.php
@@ -63,6 +63,8 @@ class ReassuranceActivity extends ObjectModel
      * @param array $psr_languages
      * @param int $type_link
      * @param int $id_cms
+     *
+     * @deprecated 6.0.0 - migrated to src/Form/PsreassuranceFormDataHandler as createLangs and updateLangs
      */
     public function handleBlockValues($psr_languages, $type_link, $id_cms)
     {
@@ -115,6 +117,8 @@ class ReassuranceActivity extends ObjectModel
      * @return array
      *
      * @throws PrestaShopDatabaseException
+     *
+     * @deprecated 6.0.0 - migrated to src/Repository/PsreassuranceRepository
      */
     public static function getAllBlock()
     {
@@ -147,6 +151,8 @@ class ReassuranceActivity extends ObjectModel
      * @return array
      *
      * @throws PrestaShopDatabaseException
+     *
+     * @deprecated 6.0.0 - migrated to src/Repository/PsreassuranceRepository
      */
     public static function getAllBlockByStatus($id_lang = 1)
     {
@@ -169,6 +175,8 @@ class ReassuranceActivity extends ObjectModel
 
     /**
      * @return string|bool
+     *
+     * @deprecated since 6.0.0 - migrated to ImageManager since PS 1.7.7.0
      */
     public static function getMimeType(string $filename)
     {

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
       "PrestaShop\\Module\\BlockReassurance\\": "src/"
     },
     "classmap": [
-      "blockreassurance.php",
-      "classes/ReassuranceActivity.php"
+      "blockreassurance.php"
     ],
     "exclude-from-classmap": []
   },

--- a/config.xml
+++ b/config.xml
@@ -7,5 +7,5 @@
     <author><![CDATA[PrestaShop]]></author>
     <is_configurable>1</is_configurable>
     <need_instance>1</need_instance>
-	<limited_countries></limited_countries>
+    <limited_countries></limited_countries>
 </module>

--- a/config/admin/index.php
+++ b/config/admin/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/config/admin/index.php
+++ b/config/admin/index.php
@@ -5,7 +5,7 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * This source file is subject to the Academic Free License version 3.0
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/AFL-3.0
@@ -13,15 +13,9 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

--- a/config/admin/services.yml
+++ b/config/admin/services.yml
@@ -1,0 +1,11 @@
+imports:
+  - { resource: ../common.yml }
+
+services:
+    block_reassurance_form_data_handler:
+        class: 'PrestaShop\Module\BlockReassurance\Form\PsreassuranceFormDataHandler'
+        public: true
+        arguments:
+            - '@block_reassurance_repository'
+            - '@prestashop.core.admin.lang.repository'
+            - '@doctrine.orm.default_entity_manager'

--- a/config/common.yml
+++ b/config/common.yml
@@ -1,0 +1,8 @@
+services:
+  block_reassurance_repository:
+    class: PrestaShop\Module\BlockReassurance\Repository\PsreassuranceRepository
+    public: true
+    arguments:
+      - '@doctrine'
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'

--- a/config/front/index.php
+++ b/config/front/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/config/front/index.php
+++ b/config/front/index.php
@@ -5,7 +5,7 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * This source file is subject to the Academic Free License version 3.0
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/AFL-3.0
@@ -13,15 +13,9 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

--- a/config/front/services.yml
+++ b/config/front/services.yml
@@ -1,0 +1,2 @@
+imports:
+  - { resource: ../common.yml }

--- a/config/index.php
+++ b/config/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/config/index.php
+++ b/config/index.php
@@ -5,7 +5,7 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * This source file is subject to the Academic Free License version 3.0
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/AFL-3.0
@@ -13,15 +13,9 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

--- a/controllers/admin/AdminBlockListingController.php
+++ b/controllers/admin/AdminBlockListingController.php
@@ -18,6 +18,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 use PrestaShop\Module\BlockReassurance\Entity\Psreassurance;
+
 class AdminBlockListingController extends ModuleAdminController
 {
     /** @var blockreassurance */

--- a/controllers/admin/AdminBlockListingController.php
+++ b/controllers/admin/AdminBlockListingController.php
@@ -164,7 +164,7 @@ class AdminBlockListingController extends ModuleAdminController
             // Last position
             $blockPsr->setPosition((int) Db::getInstance()->getValue('SELECT MAX(position) AS max FROM ' . _DB_PREFIX_ . 'psreassurance'));
             $blockPsr->setPosition($blockPsr->getPosition() ? $blockPsr->getPosition() + 1 : 1);
-            $blockPsr->setStatus(false);
+            $blockPsr->setStatus(0);
         }
 
         if (strpos($picto, $this->module->img_path_perso) !== false) {
@@ -180,15 +180,13 @@ class AdminBlockListingController extends ModuleAdminController
             $fileTmpName = $customImage['tmp_name'];
             $filename = $customImage['name'];
 
-            // validateUpload return false if no error (false -> OK)
-            if (version_compare(_PS_VERSION_, '1.7.7.0', '>=')) {
-                $validUpload = ImageManager::validateUpload(
-                    $customImage,
-                    0,
-                    $authExtensions,
-                    $authMimeType
-                );
-            }
+            $validUpload = ImageManager::validateUpload(
+                $customImage,
+                0,
+                $authExtensions,
+                $authMimeType
+            );
+
             if (is_bool($validUpload) && $validUpload === false) {
                 move_uploaded_file($fileTmpName, $this->module->folder_file_upload . $filename);
                 $blockPsr->setCustomIcon($this->module->img_path_perso . '/' . $filename);

--- a/controllers/admin/AdminBlockListingController.php
+++ b/controllers/admin/AdminBlockListingController.php
@@ -143,7 +143,7 @@ class AdminBlockListingController extends ModuleAdminController
         $picto = Tools::getValue('picto');
         $id_block = empty(Tools::getValue('id_block')) ? 0 : (int) Tools::getValue('id_block');
         $type_link = (int) Tools::getValue('typelink');
-        $id_cms = Tools::getValue('id_cms');
+        $id_cms = (int) Tools::getValue('id_cms');
         $psr_languages = (array) json_decode(Tools::getValue('lang_values'));
         $authExtensions = ['gif', 'jpg', 'jpeg', 'jpe', 'png', 'svg'];
         $authMimeType = ['image/gif', 'image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/x-png', 'image/svg', 'image/svg+xml'];

--- a/src/Entity/Psreassurance.php
+++ b/src/Entity/Psreassurance.php
@@ -1,0 +1,358 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\BlockReassurance\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Table()
+ * @ORM\Entity(repositoryClass="PrestaShop\Module\BlockReassurance\Repository\PsreassuranceRepository")
+ */
+class Psreassurance
+{
+    const TYPE_LINK_NONE = 0;
+    const TYPE_LINK_CMS_PAGE = 1;
+    const TYPE_LINK_URL = 2;
+
+    /**
+     * @var int
+     *
+     * @ORM\Id
+     * @ORM\Column(name="id_psreassurance", type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="icon", type="string", length=255)
+     */
+    private $icon;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="custom_icon", type="string", length=255)
+     */
+    private $customIcon;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="status", type="integer")
+     */
+    private $status;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="position", type="integer")
+     */
+    private $position;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="type_link", type="integer")
+     */
+    private $linkType;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="id_cms", type="integer")
+     */
+    private $cmsId;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="date_add", type="datetime", nullable=false)
+     */
+    private $dateAdd;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="date_upd", type="datetime", nullable=true)
+     */
+    private $dateUpd;
+
+    /**
+     * @ORM\OneToMany(targetEntity="PrestaShop\Module\BlockReassurance\Entity\PsreassuranceLang", cascade={"persist", "remove"}, mappedBy="psreassurance")
+     */
+    private $psreassuranceLangs;
+
+    public function __construct()
+    {
+        $this->psreassuranceLangs = new ArrayCollection();
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getPsreassuranceLangs()
+    {
+        return $this->psreassuranceLangs;
+    }
+
+    /**
+     * @param int $langId
+     *
+     * @return QuoteLang|null
+     */
+    public function getPsreassuranceLangByLangId(int $langId)
+    {
+        foreach ($this->psreassuranceLangs as $psreassuranceLang) {
+            if ($langId === $psreassuranceLang->getLang()->getId()) {
+                return $psreassuranceLang;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param PsreassuranceLang $psreassuranceLang
+     *
+     * @return $this
+     */
+    public function addPsreassuranceLang(PsreassuranceLang $psreassuranceLang)
+    {
+        $psreassuranceLang->setPsreassurance($this);
+        $this->psreassuranceLangs->add($psreassuranceLang);
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPsreassuranceTitle()
+    {
+        if ($this->psreassuranceLangs->count() <= 0) {
+            return '';
+        }
+
+        $psreassuranceLang = $this->psreassuranceLangs->first();
+
+        return $psreassuranceLang->getTitle();
+    }
+
+    /**
+     * @return string
+     */
+    public function getPsreassuranceDescription()
+    {
+        if ($this->psreassuranceLangs->count() <= 0) {
+            return '';
+        }
+
+        $psreassuranceLang = $this->psreassuranceLangs->first();
+
+        return $psreassuranceLang->getDescription();
+    }
+
+    /**
+     * @return string
+     */
+    public function getIcon()
+    {
+        return $this->icon;
+    }
+
+    /**
+     * @param string $title
+     *
+     * @return Psreassurance
+     */
+    public function setIcon($icon)
+    {
+        $this->icon = $icon;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCustomIcon()
+    {
+        return $this->customIcon;
+    }
+
+    /**
+     * @param string $customIcon
+     *
+     * @return Psreassurance
+     */
+    public function setCustomIcon($customIcon)
+    {
+        $this->customIcon = $customIcon;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param int $status
+     *
+     * @return Psreassurance
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    /**
+     * @param int $position
+     *
+     * @return Psreassurance
+     */
+    public function setPosition($position)
+    {
+        $this->position = $position;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLinkType()
+    {
+        return $this->linkType;
+    }
+
+    /**
+     * @param int $linkType
+     *
+     * @return Psreassurance
+     */
+    public function setLinkType($linkType)
+    {
+        $this->linkType = $linkType;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCmsId()
+    {
+        return $this->cmsId;
+    }
+
+    /**
+     * @param int $cmsId
+     *
+     * @return Psreassurance
+     */
+    public function setCmsId($cmsId)
+    {
+        $this->cmsId = $cmsId;
+
+        return $this;
+    }
+
+    /**
+     * Set dateAdd.
+     *
+     * @param \DateTime $dateAdd
+     *
+     * @return $this
+     */
+    public function setDateAdd(\DateTime $dateAdd)
+    {
+        $this->dateAdd = $dateAdd;
+
+        return $this;
+    }
+
+    /**
+     * Get dateAdd.
+     *
+     * @return \DateTime
+     */
+    public function getDateAdd()
+    {
+        return $this->dateAdd;
+    }
+
+    /**
+     * Set dateUpd.
+     *
+     * @param \DateTime $dateUpd
+     *
+     * @return $this
+     */
+    public function setDateUpd(\DateTime $dateUpd)
+    {
+        $this->dateUpd = $dateUpd;
+
+        return $this;
+    }
+
+    /**
+     * Get dateUpd.
+     *
+     * @return DateTime
+     */
+    public function getDateUpd()
+    {
+        return $this->dateUpd;
+    }
+}

--- a/src/Entity/Psreassurance.php
+++ b/src/Entity/Psreassurance.php
@@ -246,7 +246,7 @@ class Psreassurance
     /**
      * Set dateAdd.
      */
-    public function setDateAdd(DateTime $dateAdd): self
+    public function setDateAdd(\DateTime $dateAdd): self
     {
         $this->dateAdd = $dateAdd;
 
@@ -256,7 +256,7 @@ class Psreassurance
     /**
      * Get dateAdd.
      */
-    public function getDateAdd(): DateTime
+    public function getDateAdd(): \DateTime
     {
         return $this->dateAdd;
     }
@@ -264,7 +264,7 @@ class Psreassurance
     /**
      * Set dateUpd.
      */
-    public function setDateUpd(DateTime $dateUpd): self
+    public function setDateUpd(\DateTime $dateUpd): self
     {
         $this->dateUpd = $dateUpd;
 
@@ -274,7 +274,7 @@ class Psreassurance
     /**
      * Get dateUpd.
      */
-    public function getDateUpd(): DateTime
+    public function getDateUpd(): \DateTime
     {
         return $this->dateUpd;
     }

--- a/src/Entity/Psreassurance.php
+++ b/src/Entity/Psreassurance.php
@@ -17,6 +17,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
+declare(strict_types=1);
 
 namespace PrestaShop\Module\BlockReassurance\Entity;
 

--- a/src/Entity/Psreassurance.php
+++ b/src/Entity/Psreassurance.php
@@ -5,7 +5,7 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * This source file is subject to the Academic Free License version 3.0
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/AFL-3.0
@@ -13,15 +13,9 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
 namespace PrestaShop\Module\BlockReassurance\Entity;

--- a/src/Entity/Psreassurance.php
+++ b/src/Entity/Psreassurance.php
@@ -32,6 +32,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Table()
+ *
  * @ORM\Entity(repositoryClass="PrestaShop\Module\BlockReassurance\Repository\PsreassuranceRepository")
  */
 class Psreassurance
@@ -44,7 +45,9 @@ class Psreassurance
      * @var int
      *
      * @ORM\Id
+     *
      * @ORM\Column(name="id_psreassurance", type="integer")
+     *
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     private $id;

--- a/src/Entity/Psreassurance.php
+++ b/src/Entity/Psreassurance.php
@@ -112,10 +112,7 @@ class Psreassurance
         $this->psreassuranceLangs = new ArrayCollection();
     }
 
-    /**
-     * @return int
-     */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
@@ -144,12 +141,7 @@ class Psreassurance
         return null;
     }
 
-    /**
-     * @param PsreassuranceLang $psreassuranceLang
-     *
-     * @return $this
-     */
-    public function addPsreassuranceLang(PsreassuranceLang $psreassuranceLang)
+    public function addPsreassuranceLang(PsreassuranceLang $psreassuranceLang): self
     {
         $psreassuranceLang->setPsreassurance($this);
         $this->psreassuranceLangs->add($psreassuranceLang);
@@ -157,10 +149,7 @@ class Psreassurance
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getPsreassuranceTitle()
+    public function getPsreassuranceTitle(): string
     {
         if ($this->psreassuranceLangs->count() <= 0) {
             return '';
@@ -171,10 +160,7 @@ class Psreassurance
         return $psreassuranceLang->getTitle();
     }
 
-    /**
-     * @return string
-     */
-    public function getPsreassuranceDescription()
+    public function getPsreassuranceDescription(): string
     {
         if ($this->psreassuranceLangs->count() <= 0) {
             return '';
@@ -185,120 +171,72 @@ class Psreassurance
         return $psreassuranceLang->getDescription();
     }
 
-    /**
-     * @return string
-     */
-    public function getIcon()
+    public function getIcon(): string
     {
         return $this->icon;
     }
 
-    /**
-     * @param string $title
-     *
-     * @return Psreassurance
-     */
-    public function setIcon($icon)
+    public function setIcon(string $icon): self
     {
         $this->icon = $icon;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getCustomIcon()
+    public function getCustomIcon(): string
     {
         return $this->customIcon;
     }
 
-    /**
-     * @param string $customIcon
-     *
-     * @return Psreassurance
-     */
-    public function setCustomIcon($customIcon)
+    public function setCustomIcon(string $customIcon): self
     {
         $this->customIcon = $customIcon;
 
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getStatus()
+    public function getStatus(): int
     {
         return $this->status;
     }
 
-    /**
-     * @param int $status
-     *
-     * @return Psreassurance
-     */
-    public function setStatus($status)
+    public function setStatus(int $status): self
     {
         $this->status = $status;
 
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getPosition()
+    public function getPosition(): int
     {
         return $this->position;
     }
 
-    /**
-     * @param int $position
-     *
-     * @return Psreassurance
-     */
-    public function setPosition($position)
+    public function setPosition(int $position): self
     {
         $this->position = $position;
 
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getLinkType()
+    public function getLinkType(): int
     {
         return $this->linkType;
     }
 
-    /**
-     * @param int $linkType
-     *
-     * @return Psreassurance
-     */
-    public function setLinkType($linkType)
+    public function setLinkType(int $linkType): self
     {
         $this->linkType = $linkType;
 
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getCmsId()
+    public function getCmsId(): int
     {
         return $this->cmsId;
     }
 
-    /**
-     * @param int $cmsId
-     *
-     * @return Psreassurance
-     */
-    public function setCmsId($cmsId)
+    public function setCmsId(int $cmsId): self
     {
         $this->cmsId = $cmsId;
 
@@ -307,12 +245,8 @@ class Psreassurance
 
     /**
      * Set dateAdd.
-     *
-     * @param \DateTime $dateAdd
-     *
-     * @return $this
      */
-    public function setDateAdd(\DateTime $dateAdd)
+    public function setDateAdd(DateTime $dateAdd): self
     {
         $this->dateAdd = $dateAdd;
 
@@ -321,22 +255,16 @@ class Psreassurance
 
     /**
      * Get dateAdd.
-     *
-     * @return \DateTime
      */
-    public function getDateAdd()
+    public function getDateAdd(): DateTime
     {
         return $this->dateAdd;
     }
 
     /**
      * Set dateUpd.
-     *
-     * @param \DateTime $dateUpd
-     *
-     * @return $this
      */
-    public function setDateUpd(\DateTime $dateUpd)
+    public function setDateUpd(DateTime $dateUpd): self
     {
         $this->dateUpd = $dateUpd;
 
@@ -345,10 +273,8 @@ class Psreassurance
 
     /**
      * Get dateUpd.
-     *
-     * @return DateTime
      */
-    public function getDateUpd()
+    public function getDateUpd(): DateTime
     {
         return $this->dateUpd;
     }

--- a/src/Entity/Psreassurance.php
+++ b/src/Entity/Psreassurance.php
@@ -23,7 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
-declare(strict_types=1);
 
 namespace PrestaShop\Module\BlockReassurance\Entity;
 

--- a/src/Entity/PsreassuranceLang.php
+++ b/src/Entity/PsreassuranceLang.php
@@ -16,40 +16,50 @@ use PrestaShopBundle\Entity\Lang;
 
 /**
  * @ORM\Table()
+ *
  * @ORM\Entity()
  */
 class PsreassuranceLang
 {
     /**
      * @var Psreassurance
+     *
      * @ORM\Id
+     *
      * @ORM\ManyToOne(targetEntity="PrestaShop\Module\BlockReassurance\Entity\Psreassurance", inversedBy="psreassuranceLangs")
+     *
      * @ORM\JoinColumn(name="id_psreassurance", referencedColumnName="id_psreassurance", nullable=false)
      */
     private $psreassurance;
 
     /**
      * @var Lang
+     *
      * @ORM\Id
+     *
      * @ORM\ManyToOne(targetEntity="PrestaShopBundle\Entity\Lang")
+     *
      * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false, onDelete="CASCADE")
      */
     private $lang;
 
     /**
      * @var string
+     *
      * @ORM\Column(name="title", type="string", nullable=false)
      */
     private $title;
 
     /**
      * @var string
+     *
      * @ORM\Column(name="description", type="string", nullable=false)
      */
     private $description;
 
     /**
      * @var string
+     *
      * @ORM\Column(name="link", type="string", nullable=true)
      */
     private $link;

--- a/src/Entity/PsreassuranceLang.php
+++ b/src/Entity/PsreassuranceLang.php
@@ -7,7 +7,6 @@
  * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
  * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
  */
-declare(strict_types=1);
 
 namespace PrestaShop\Module\BlockReassurance\Entity;
 

--- a/src/Entity/PsreassuranceLang.php
+++ b/src/Entity/PsreassuranceLang.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * 2007-2020 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
+ * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\Module\BlockReassurance\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use PrestaShopBundle\Entity\Lang;
+
+/**
+ * @ORM\Table()
+ * @ORM\Entity()
+ */
+class PsreassuranceLang
+{
+    /**
+     * @var Psreassurance
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="PrestaShop\Module\BlockReassurance\Entity\Psreassurance", inversedBy="psreassuranceLangs")
+     * @ORM\JoinColumn(name="id_psreassurance", referencedColumnName="id_psreassurance", nullable=false)
+     */
+    private $psreassurance;
+
+    /**
+     * @var Lang
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="PrestaShopBundle\Entity\Lang")
+     * @ORM\JoinColumn(name="id_lang", referencedColumnName="id_lang", nullable=false, onDelete="CASCADE")
+     */
+    private $lang;
+
+    /**
+     * @var string
+     * @ORM\Column(name="title", type="string", nullable=false)
+     */
+    private $title;
+
+    /**
+     * @var string
+     * @ORM\Column(name="description", type="string", nullable=false)
+     */
+    private $description;
+
+    /**
+     * @var string
+     * @ORM\Column(name="link", type="string", nullable=true)
+     */
+    private $link;
+
+    /**
+     * @return Psreassurance
+     */
+    public function getPsreassurance()
+    {
+        return $this->psreassurance;
+    }
+
+    /**
+     * @param Psreassurance $psreassurance
+     *
+     * @return $this
+     */
+    public function setPsreassurance(Psreassurance $psreassurance)
+    {
+        $this->psreassurance = $psreassurance;
+
+        return $this;
+    }
+
+    /**
+     * @return Lang
+     */
+    public function getLang()
+    {
+        return $this->lang;
+    }
+
+    /**
+     * @param Lang $lang
+     *
+     * @return $this
+     */
+    public function setLang(Lang $lang)
+    {
+        $this->lang = $lang;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     *
+     * @return $this
+     */
+    public function setTitle(string $title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $description
+     *
+     * @return $this
+     */
+    public function setDescription(string $description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLink()
+    {
+        return $this->link;
+    }
+
+    /**
+     * @param string $link
+     *
+     * @return $this
+     */
+    public function setLink(string $link)
+    {
+        $this->link = $link;
+
+        return $this;
+    }
+}

--- a/src/Entity/PsreassuranceLang.php
+++ b/src/Entity/PsreassuranceLang.php
@@ -74,10 +74,8 @@ class PsreassuranceLang
 
     /**
      * @param Psreassurance $psreassurance
-     *
-     * @return $this
      */
-    public function setPsreassurance(Psreassurance $psreassurance)
+    public function setPsreassurance(Psreassurance $psreassurance): self
     {
         $this->psreassurance = $psreassurance;
 
@@ -94,70 +92,44 @@ class PsreassuranceLang
 
     /**
      * @param Lang $lang
-     *
-     * @return $this
      */
-    public function setLang(Lang $lang)
+    public function setLang(Lang $lang): self
     {
         $this->lang = $lang;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
 
-    /**
-     * @param string $title
-     *
-     * @return $this
-     */
-    public function setTitle(string $title)
+    public function setTitle(string $title): self
     {
         $this->title = $title;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * @param string $description
-     *
-     * @return $this
-     */
-    public function setDescription(string $description)
+    public function setDescription(string $description): self
     {
         $this->description = $description;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getLink()
+    public function getLink(): string
     {
         return $this->link;
     }
 
-    /**
-     * @param string $link
-     *
-     * @return $this
-     */
-    public function setLink(string $link)
+    public function setLink(string $link): self
     {
         $this->link = $link;
 

--- a/src/Entity/PsreassuranceLang.php
+++ b/src/Entity/PsreassuranceLang.php
@@ -7,6 +7,7 @@
  * This source file is subject to the Academic Free License 3.0 (AFL-3.0).
  * It is also available through the world-wide-web at this URL: https://opensource.org/licenses/AFL-3.0
  */
+declare(strict_types=1);
 
 namespace PrestaShop\Module\BlockReassurance\Entity;
 

--- a/src/Entity/index.php
+++ b/src/Entity/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Entity/index.php
+++ b/src/Entity/index.php
@@ -5,7 +5,7 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * This source file is subject to the Academic Free License version 3.0
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/AFL-3.0
@@ -13,15 +13,9 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

--- a/src/Form/PsreassuranceFormDataHandler.php
+++ b/src/Form/PsreassuranceFormDataHandler.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\BlockReassurance\Form;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\Module\BlockReassurance\Entity\Psreassurance;
+use PrestaShop\Module\BlockReassurance\Entity\PsreassuranceLang;
+use PrestaShop\Module\BlockReassurance\Repository\PsreassuranceRepository;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\FormDataHandlerInterface;
+use PrestaShopBundle\Entity\Repository\LangRepository;
+
+class PsreassuranceFormDataHandler implements FormDataHandlerInterface
+{
+    /**
+     * @var PsreassuranceRepository
+     */
+    private $psreassuranceRepository;
+
+    /**
+     * @var LangRepository
+     */
+    private $langRepository;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * @param PsreassuranceeRepository $psreassuranceRepository
+     * @param LangRepository $langRepository
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(
+        PsreassuranceRepository $psreassuranceRepository,
+        LangRepository $langRepository,
+        EntityManagerInterface $entityManager
+    ) {
+        $this->psreassuranceRepository = $psreassuranceRepository;
+        $this->langRepository = $langRepository;
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $data)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function update($id, array $data)
+    {
+    }
+
+    /**
+     * @param Psreassurance $psreassurance
+     * @param array $psr_languages
+     * @param int $type_link
+     * @param int $id_cms
+     * @todo migrate this temporary function to above standard function create()
+     */
+    public function createLangs($psreassurance, $psr_languages, $type_link, $id_cms): void
+    {
+        foreach ($psr_languages as $langId => $langContent) {
+            $lang = $this->langRepository->findOneById($langId);
+            $psreassuranceLang = new PsreassuranceLang();
+            $psreassuranceLang
+                ->setLang($lang)
+                ->setTitle($langContent->title)
+                ->setDescription($langContent->description)
+                ->setLink($langContent->url)
+            ;
+            if (!empty($id_cms) && $type_link === Psreassurance::TYPE_LINK_CMS_PAGE) {
+                $psreassurance->setCmsId($id_cms);
+                $link = \Context::getContext()->link;
+                $psreassuranceLang->setLink(
+                    $link->getCMSLink($id_cms, null, null, $langId)
+                );
+            }
+            $psreassurance->addPsreassuranceLang($psreassuranceLang);
+        }
+
+        if ($type_link == 'undefined') {
+            $type_link = Psreassurance::TYPE_LINK_NONE;
+        }
+        $psreassurance->setLinkType($type_link);
+
+        $this->entityManager->persist($psreassurance);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @param Psreassurance $psreassurance
+     * @param array $psr_languages
+     * @param int $type_link
+     * @param int $id_cms
+     * @todo migrate this temporary function to above standard function update()
+     */
+    public function updateLangs($psreassurance, $psr_languages, $type_link, $id_cms): void
+    {
+        foreach ($psr_languages as $langId => $langContent) {
+            $lang = $this->langRepository->findOneById($langId);
+            $psreassuranceLang = $psreassurance->getPsreassuranceLangByLangId($langId);
+            if (null === $psreassuranceLang) {
+                continue;
+            }
+            $psreassuranceLang
+                ->setTitle($langContent->title)
+                ->setDescription($langContent->description)
+                ->setLink($langContent->url)
+            ;
+            if (!empty($id_cms) && $type_link === Psreassurance::TYPE_LINK_CMS_PAGE) {
+                $psreassurance->setCmsId($id_cms);
+                $link = \Context::getContext()->link;
+                $psreassuranceLang->setLink(
+                    $link->getCMSLink($id_cms, null, null, $langId)
+                );
+            }
+        }
+
+        if ($type_link == 'undefined') {
+            $type_link = Psreassurance::TYPE_LINK_NONE;
+        }
+        $psreassurance->setLinkType($type_link);
+
+        $this->entityManager->persist($psreassurance);
+        $this->entityManager->flush();
+    }
+}

--- a/src/Form/PsreassuranceFormDataHandler.php
+++ b/src/Form/PsreassuranceFormDataHandler.php
@@ -129,7 +129,7 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
      *
      * @todo migrate this temporary function to above standard function update
      */
-    public function updateLangs($psreassurance, $psr_languages, $type_link, $id_cms): void
+    public function updateLangs($psreassurance, $psr_languages, $type_link, $id_cms)
     {
         foreach ($psr_languages as $langId => $langContent) {
             $lang = $this->langRepository->findOneById($langId);

--- a/src/Form/PsreassuranceFormDataHandler.php
+++ b/src/Form/PsreassuranceFormDataHandler.php
@@ -80,11 +80,9 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
      * @param int $type_link
      * @param int $id_cms
      *
-     * @return void
-     *
      * @todo migrate this temporary function to above standard function create
      */
-    public function createLangs($psreassurance, $psr_languages, $type_link, $id_cms)
+    public function createLangs($psreassurance, $psr_languages, $type_link, $id_cms): void
     {
         foreach ($psr_languages as $langId => $langContent) {
             $lang = $this->langRepository->findOneById($langId);
@@ -120,11 +118,9 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
      * @param int $type_link
      * @param int $id_cms
      *
-     * @return void
-     *
      * @todo migrate this temporary function to above standard function update
      */
-    public function updateLangs($psreassurance, $psr_languages, $type_link, $id_cms)
+    public function updateLangs($psreassurance, $psr_languages, $type_link, $id_cms): void
     {
         foreach ($psr_languages as $langId => $langContent) {
             $lang = $this->langRepository->findOneById($langId);

--- a/src/Form/PsreassuranceFormDataHandler.php
+++ b/src/Form/PsreassuranceFormDataHandler.php
@@ -24,8 +24,6 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 
-declare(strict_types=1);
-
 namespace PrestaShop\Module\BlockReassurance\Form;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/src/Form/PsreassuranceFormDataHandler.php
+++ b/src/Form/PsreassuranceFormDataHandler.php
@@ -85,7 +85,7 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
     public function createLangs($psreassurance, $psr_languages, $type_link, $id_cms): void
     {
         foreach ($psr_languages as $langId => $langContent) {
-            $lang = $this->langRepository->findOneById($langId);
+            $lang = $this->langRepository->find($langId);
             $psreassuranceLang = new PsreassuranceLang();
             $psreassuranceLang
                 ->setLang($lang)
@@ -123,7 +123,7 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
     public function updateLangs($psreassurance, $psr_languages, $type_link, $id_cms): void
     {
         foreach ($psr_languages as $langId => $langContent) {
-            $lang = $this->langRepository->findOneById($langId);
+            $lang = $this->langRepository->find($langId);
             $psreassuranceLang = $psreassurance->getPsreassuranceLangByLangId($langId);
             if (null === $psreassuranceLang) {
                 continue;

--- a/src/Form/PsreassuranceFormDataHandler.php
+++ b/src/Form/PsreassuranceFormDataHandler.php
@@ -83,9 +83,9 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
      * @param Psreassurance $psreassurance
      * @param array $psr_languages
      * @param int $type_link
-     * @param int $id_cms
+     * @param int $id_cms     
      *
-     * @todo migrate this temporary function to above standard function create()
+     * @todo migrate this temporary function to above standard function create
      */
     public function createLangs($psreassurance, $psr_languages, $type_link, $id_cms): void
     {
@@ -121,9 +121,9 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
      * @param Psreassurance $psreassurance
      * @param array $psr_languages
      * @param int $type_link
-     * @param int $id_cms
+     * @param int $id_cms     
      *
-     * @todo migrate this temporary function to above standard function update()
+     * @todo migrate this temporary function to above standard function update
      */
     public function updateLangs($psreassurance, $psr_languages, $type_link, $id_cms): void
     {

--- a/src/Form/PsreassuranceFormDataHandler.php
+++ b/src/Form/PsreassuranceFormDataHandler.php
@@ -5,7 +5,7 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * This source file is subject to the Academic Free License version 3.0
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/AFL-3.0
@@ -13,15 +13,9 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
 namespace PrestaShop\Module\BlockReassurance\Form;

--- a/src/Form/PsreassuranceFormDataHandler.php
+++ b/src/Form/PsreassuranceFormDataHandler.php
@@ -85,9 +85,11 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
      * @param int $type_link
      * @param int $id_cms
      *
+     * @return void
+     *
      * @todo migrate this temporary function to above standard function create
      */
-    public function createLangs($psreassurance, $psr_languages, $type_link, $id_cms): void
+    public function createLangs($psreassurance, $psr_languages, $type_link, $id_cms)
     {
         foreach ($psr_languages as $langId => $langContent) {
             $lang = $this->langRepository->findOneById($langId);
@@ -122,6 +124,8 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
      * @param array $psr_languages
      * @param int $type_link
      * @param int $id_cms
+     *
+     * @return void
      *
      * @todo migrate this temporary function to above standard function update
      */

--- a/src/Form/PsreassuranceFormDataHandler.php
+++ b/src/Form/PsreassuranceFormDataHandler.php
@@ -83,7 +83,7 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
      * @param Psreassurance $psreassurance
      * @param array $psr_languages
      * @param int $type_link
-     * @param int $id_cms     
+     * @param int $id_cms
      *
      * @todo migrate this temporary function to above standard function create
      */
@@ -121,7 +121,7 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
      * @param Psreassurance $psreassurance
      * @param array $psr_languages
      * @param int $type_link
-     * @param int $id_cms     
+     * @param int $id_cms
      *
      * @todo migrate this temporary function to above standard function update
      */

--- a/src/Form/PsreassuranceFormDataHandler.php
+++ b/src/Form/PsreassuranceFormDataHandler.php
@@ -17,6 +17,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
+declare(strict_types=1);
 
 namespace PrestaShop\Module\BlockReassurance\Form;
 

--- a/src/Form/PsreassuranceFormDataHandler.php
+++ b/src/Form/PsreassuranceFormDataHandler.php
@@ -86,6 +86,7 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
      * @param array $psr_languages
      * @param int $type_link
      * @param int $id_cms
+     *
      * @todo migrate this temporary function to above standard function create()
      */
     public function createLangs($psreassurance, $psr_languages, $type_link, $id_cms): void
@@ -123,6 +124,7 @@ class PsreassuranceFormDataHandler implements FormDataHandlerInterface
      * @param array $psr_languages
      * @param int $type_link
      * @param int $id_cms
+     *
      * @todo migrate this temporary function to above standard function update()
      */
     public function updateLangs($psreassurance, $psr_languages, $type_link, $id_cms): void

--- a/src/Repository/PsreassuranceRepository.php
+++ b/src/Repository/PsreassuranceRepository.php
@@ -142,7 +142,7 @@ class PsreassuranceRepository extends ServiceEntityRepository
         $xmlMimes = ['image/svg', 'image/svg+xml'];
         foreach ($result as &$item) {
             $item['is_svg'] = !empty($item['custom_icon'])
-                && (in_array(\ImageManager::getMimeType(_PS_ROOT_DIR_ . $item['custom_icon']), $xmlMimes));
+                && in_array(\ImageManager::getMimeType(_PS_ROOT_DIR_ . $item['custom_icon']), $xmlMimes);
         }
 
         return $result;

--- a/src/Repository/PsreassuranceRepository.php
+++ b/src/Repository/PsreassuranceRepository.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+namespace PrestaShop\Module\BlockReassurance\Repository;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ManagerRegistry;
+use PrestaShop\Module\BlockReassurance\Entity\Psreassurance;
+
+/**
+ * @extends ServiceEntityRepository<Psreassurance>
+ *
+ * @method Psreassurance|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Psreassurance|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Psreassurance[] findAll()
+ * @method Psreassurance[] findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class PsreassuranceRepository extends ServiceEntityRepository
+{
+    /**
+     * @var ManagerRegistry the Doctrine Registry
+     */
+    private $registry;
+
+    /**
+     * @var Connection the Database connection
+     */
+    private $connection;
+
+    /**
+     * @var string the Database prefix
+     */
+    private $databasePrefix;
+
+    /**
+     * @param ManagerRegistry $registry
+     * @param Connection $connection
+     * @param string $databasePrefix
+     */
+    public function __construct(
+        $registry,
+        $connection,
+        $databasePrefix
+    ) {
+        parent::__construct($registry, Psreassurance::class);
+        $this->connection = $connection;
+        $this->databasePrefix = $databasePrefix;
+    }
+
+    public function add(Psreassurance $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(Psreassurance $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->remove($entity);
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getAllBlock()
+    {
+        $result = [];
+
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->addSelect('*')
+            ->from($this->databasePrefix . 'psreassurance', 'pr')
+            ->leftJoin('pr', $this->databasePrefix . 'psreassurance_lang', 'prl', 'pr.id_psreassurance = prl.id_psreassurance')
+            ->addOrderBy('pr.position', 'ASC')
+        ;
+
+        $dbResult = $qb->execute()->fetchAll();
+
+        foreach ($dbResult as $key => $value) {
+            if (!isset($result[$value['id_psreassurance']])) {
+                $result[$value['id_psreassurance']] = $value;
+                $result[$value['id_psreassurance']]['title'] = [];
+                $result[$value['id_psreassurance']]['description'] = [];
+                $result[$value['id_psreassurance']]['url'] = [];
+            }
+            $result[$value['id_psreassurance']]['title'][$value['id_lang']] = $value['title'];
+            $result[$value['id_psreassurance']]['description'][$value['id_lang']] = $value['description'];
+            $result[$value['id_psreassurance']]['url'][$value['id_lang']] = $value['link'];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param int $id_lang
+     *
+     * @return array
+     */
+    public function getAllBlockByStatus($id_lang = 1)
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->addSelect('*')
+            ->from($this->databasePrefix . 'psreassurance', 'pr')
+            ->leftJoin('pr', $this->databasePrefix . 'psreassurance_lang', 'prl', 'pr.id_psreassurance = prl.id_psreassurance')
+            ->andWhere('pr.status = 1')
+            ->andWhere('prl.id_lang = :id_lang')
+            ->setParameter('id_lang', $id_lang)
+            ->addOrderBy('pr.position', 'ASC')
+        ;
+        $result = $qb->execute()->fetchAll();
+
+        $xmlMimes = ['image/svg', 'image/svg+xml'];
+        foreach ($result as &$item) {
+            $item['is_svg'] = !empty($item['custom_icon'])
+                && (in_array(\ImageManager::getMimeType(_PS_ROOT_DIR_ . $item['custom_icon']), $xmlMimes));
+        }
+
+        return $result;
+    }
+}

--- a/src/Repository/PsreassuranceRepository.php
+++ b/src/Repository/PsreassuranceRepository.php
@@ -5,7 +5,7 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * This source file is subject to the Academic Free License version 3.0
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/AFL-3.0
@@ -13,15 +13,9 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
 namespace PrestaShop\Module\BlockReassurance\Repository;

--- a/src/Repository/PsreassuranceRepository.php
+++ b/src/Repository/PsreassuranceRepository.php
@@ -71,7 +71,13 @@ class PsreassuranceRepository extends ServiceEntityRepository
         $this->databasePrefix = $databasePrefix;
     }
 
-    public function add(Psreassurance $entity, bool $flush = false): void
+    /**
+     * @param Psreassurance $entity
+     * @param bool $flush
+     *
+     * @return void
+     */
+    public function add($entity, $flush = false)
     {
         $this->getEntityManager()->persist($entity);
 
@@ -80,7 +86,13 @@ class PsreassuranceRepository extends ServiceEntityRepository
         }
     }
 
-    public function remove(Psreassurance $entity, bool $flush = false): void
+    /**
+     * @param Psreassurance $entity
+     * @param bool $flush
+     *
+     * @return void
+     */
+    public function remove($entity, $flush = false)
     {
         $this->getEntityManager()->remove($entity);
         if ($flush) {

--- a/src/Repository/PsreassuranceRepository.php
+++ b/src/Repository/PsreassuranceRepository.php
@@ -65,13 +65,7 @@ class PsreassuranceRepository extends ServiceEntityRepository
         $this->databasePrefix = $databasePrefix;
     }
 
-    /**
-     * @param Psreassurance $entity
-     * @param bool $flush
-     *
-     * @return void
-     */
-    public function add($entity, $flush = false)
+    public function add(Psreassurance $entity, bool $flush = false): void
     {
         $this->getEntityManager()->persist($entity);
 
@@ -80,13 +74,7 @@ class PsreassuranceRepository extends ServiceEntityRepository
         }
     }
 
-    /**
-     * @param Psreassurance $entity
-     * @param bool $flush
-     *
-     * @return void
-     */
-    public function remove($entity, $flush = false)
+    public function remove(Psreassurance $entity, bool $flush = false): void
     {
         $this->getEntityManager()->remove($entity);
         if ($flush) {

--- a/src/Repository/index.php
+++ b/src/Repository/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/src/Repository/index.php
+++ b/src/Repository/index.php
@@ -5,7 +5,7 @@
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * This source file is subject to the Academic Free License version 3.0
  * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/AFL-3.0
@@ -13,15 +13,9 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://devdocs.prestashop.com/ for more information.
- *
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
- * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');

--- a/tests/phpstan/phpstan-1.7.7.neon
+++ b/tests/phpstan/phpstan-1.7.7.neon
@@ -3,4 +3,4 @@ includes:
 
 parameters:
   ignoreErrors:
-    - '#Parameter \#1 \$value of method ControllerCore::ajaxRender\(\) expects null, string|false given.#'
+    - '#Parameter \#1 \$value of method ControllerCore::ajaxRender\(\) expects null, string\|false given.#'

--- a/tests/phpstan/phpstan.neon
+++ b/tests/phpstan/phpstan.neon
@@ -9,3 +9,7 @@ parameters:
     - ../../translations/
     - ../../upgrade/
   level: 5
+  ignoreErrors:
+  - 
+    message: '#Cannot call method [a-zA-Z0-9\\_]+\(\) on object\|false.#'
+    path: ../../blockreassurance.php


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Migrate ObjectModel-based classes/ReassuranceActivity to Doctrine src/* <br> Deprecate ReassuranceActivity and all of its functions.
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | PrestaShop/PrestaShop/discussions/34472
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | 1. Apply this PR changes. <br> 2. In FO: clear browser cache & In BO: Performance > clear cache. <br> 3. Check all module features in both FO and BO to make sure they work as usual, especially multilingual feature for block title/description/link.
