### PR TITLE
Added avif support to blockreassurance icon images

### DIFF
--- a/controllers/admin/AdminBlockListingController.php
+++ b/controllers/admin/AdminBlockListingController.php
@@ -149,7 +149,7 @@ class AdminBlockListingController extends ModuleAdminController
         $authMimeType = ['image/gif', 'image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/x-png', 'image/svg', 'image/svg+xml', 'image/avif'];
 
         if (!empty($picto) && !in_array(pathinfo($picto, PATHINFO_EXTENSION), $authExtensions)) {
-            $errors[] = Context::getContext()->getTranslator()->trans('Image format not recognized, allowed formats are: .gif, .jpg, .png', [], 'Admin.Notifications.Error');
+            $errors[] = Context::getContext()->getTranslator()->trans('Image format not recognized, allowed formats are: .gif, .jpg, .png, .svg, .avif', [], 'Admin.Notifications.Error');
 
             return $this->ajaxRenderJson(empty($errors) ? 'success' : 'error');
         }

--- a/controllers/admin/AdminBlockListingController.php
+++ b/controllers/admin/AdminBlockListingController.php
@@ -145,8 +145,8 @@ class AdminBlockListingController extends ModuleAdminController
         $type_link = (int) Tools::getValue('typelink');
         $id_cms = (int) Tools::getValue('id_cms');
         $psr_languages = (array) json_decode(Tools::getValue('lang_values'));
-        $authExtensions = ['gif', 'jpg', 'jpeg', 'jpe', 'png', 'svg'];
-        $authMimeType = ['image/gif', 'image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/x-png', 'image/svg', 'image/svg+xml'];
+        $authExtensions = ['gif', 'jpg', 'jpeg', 'jpe', 'png', 'svg', 'avif'];
+        $authMimeType = ['image/gif', 'image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/x-png', 'image/svg', 'image/svg+xml', 'image/avif'];
 
         if (!empty($picto) && !in_array(pathinfo($picto, PATHINFO_EXTENSION), $authExtensions)) {
             $errors[] = Context::getContext()->getTranslator()->trans('Image format not recognized, allowed formats are: .gif, .jpg, .png', [], 'Admin.Notifications.Error');

--- a/views/templates/admin/tabs/content/config_elements/icon.tpl
+++ b/views/templates/admin/tabs/content/config_elements/icon.tpl
@@ -46,7 +46,7 @@
             </label>
         </div>
         <div class="help-block">
-            {l s='Choose SVG for better customization. Other allowed formats are: .gif, .jpg, .png' d='Modules.Blockreassurance.Admin'}
+            {l s='Choose SVG for better customization. Other allowed formats are: .gif, .jpg, .png, .avif' d='Modules.Blockreassurance.Admin'}
         </div>
     </div>
     <div class="clearfix"></div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I have added support to this new image format.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no

Hi guys, I have simply added new .avif extension and image/avif mimetype to authorized.
