### PR TITLE
Revert sass-loader from 14 to 13 to be compatible with Node16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "file-loader": "^6.2.0",
         "mini-css-extract-plugin": "^2.8.0",
         "node-sass": "^8.0.0",
-        "sass-loader": "^14.1.0",
+        "sass-loader": "^13.3.3",
         "style-loader": "^3.3.4",
         "webpack": "^5.90.1",
         "webpack-cli": "^5.1.4"
@@ -5618,29 +5618,29 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-14.1.0.tgz",
-      "integrity": "sha512-LS2mLeFWA+orYxHNu+O18Xe4jR0kyamNOOUsE3NyBP4DvIL+8stHpNX0arYTItdPe80kluIiJ7Wfe/9iHSRO0Q==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.3.3.tgz",
+      "integrity": "sha512-mt5YN2F1MOZr3d/wBRcZxeFgwgkH44wVc2zohO2YF6JiOMkiXe4BYRZpSu2sO1g71mo/j16txzUhsKZlqjVGzA==",
       "dev": true,
       "dependencies": {
         "neo-async": "^2.6.2"
       },
       "engines": {
-        "node": ">= 18.12.0"
+        "node": ">= 14.15.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
+        "fibers": ">= 3.1.0",
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
         "sass-embedded": "*",
         "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "@rspack/core": {
+        "fibers": {
           "optional": true
         },
         "node-sass": {
@@ -5650,9 +5650,6 @@
           "optional": true
         },
         "sass-embedded": {
-          "optional": true
-        },
-        "webpack": {
           "optional": true
         }
       }
@@ -10921,9 +10918,9 @@
       }
     },
     "sass-loader": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-14.1.0.tgz",
-      "integrity": "sha512-LS2mLeFWA+orYxHNu+O18Xe4jR0kyamNOOUsE3NyBP4DvIL+8stHpNX0arYTItdPe80kluIiJ7Wfe/9iHSRO0Q==",
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.3.3.tgz",
+      "integrity": "sha512-mt5YN2F1MOZr3d/wBRcZxeFgwgkH44wVc2zohO2YF6JiOMkiXe4BYRZpSu2sO1g71mo/j16txzUhsKZlqjVGzA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "file-loader": "^6.2.0",
     "mini-css-extract-plugin": "^2.8.0",
     "node-sass": "^8.0.0",
-    "sass-loader": "^14.1.0",
+    "sass-loader": "^13.3.3",
     "style-loader": "^3.3.4",
     "webpack": "^5.90.1",
     "webpack-cli": "^5.1.4"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | sass-loader 14.1.0 require at least Node 18.12.0, that most of packages in this repo are not compatible to. dependabot tried to bump sass-loader from v13 to v14 in https://github.com/PrestaShop/blockreassurance/pull/638 and https://github.com/PrestaShop/blockreassurance/pull/643
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue URL here}, Fixes #{another issue URL here}
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Apply the PR change, then try `npm install` & `npm run build` with Node 16

![Screenshot from 2024-02-17 11-12-11](https://github.com/PrestaShop/blockreassurance/assets/159242502/a35132a5-c56d-4054-a75c-0d83702380ce)

