### PR TITLE
Bump PS minimum to 1.7.8 for prestashop.core.admin.lang.repository service

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta-versions: ['1.7.7', '1.7.8', '8.0', 'latest']
+        presta-versions: ['1.7.8', '8.0', 'latest']
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -127,7 +127,7 @@ class blockreassurance extends Module implements WidgetInterface
         // Confirm uninstall
         $this->confirmUninstall = $this->trans('Are you sure you want to uninstall this module?', [], 'Modules.Blockreassurance.Admin');
         $this->ps_url = $this->context->link->getBaseLink();
-        $this->ps_versions_compliancy = ['min' => '1.7.7', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '1.7.8', 'max' => _PS_VERSION_];
         $this->templateFile = 'module:blockreassurance/views/templates/hook/blockreassurance.tpl';
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | [prestashop.core.admin.lang.repository service](https://github.com/PrestaShop/blockreassurance/blob/dev/config/admin/services.yml#L10) requires PS 1.7.8+
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [35886](PrestaShop/PrestaShop/issues/35886) (issue for productcomments, but is similar to blockreassurance)
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Upgrade to new version is OK on PS 1.7.8+
