### PR TITLE
Drop node14, downgrade css-loader n sass-loader to fit with node16

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -6,11 +6,11 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-versions: [ '14', '16' ]
+                node-versions: [ '16' ]
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+              uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-versions }}
             - run: npm install

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@babel/eslint-parser": "^7.24.5",    
     "babel-loader": "^9.1.3",
     "clean-webpack-plugin": "^4.0.0",
-    "css-loader": "^6.10.0",
+    "css-loader": "^6.11.0",
     "eslint": "^8.56.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prestashop": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@babel/eslint-parser": "^7.24.5",    
     "babel-loader": "^9.1.3",
     "clean-webpack-plugin": "^4.0.0",
-    "css-loader": "^7.1.1",
+    "css-loader": "^6.10.0",
     "eslint": "^8.56.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prestashop": "^0.2.1",
@@ -30,7 +30,7 @@
     "file-loader": "^6.2.0",
     "mini-css-extract-plugin": "^2.9.0",
     "node-sass": "^8.0.0",
-    "sass-loader": "^14.2.1",
+    "sass-loader": "^13.3.3",
     "style-loader": "^3.3.4",
     "webpack": "^5.90.1",
     "webpack-cli": "^5.1.4"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Drop node14; current css-loader 7 and  sass-loader 14 require at least node18 so need downgrade to be compatible with node16
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue URL here}, Fixes #{another issue URL here}
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | CI green; `npm install` and `npm run build` with node16 can complete without error.
