### PR TITLE
Fix: Problem with the blockreassurance module in case of a site in a subfolder

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -89,6 +89,9 @@ class blockreassurance extends Module implements WidgetInterface
     public $folder_file_upload;
     /** @var string */
     private $templateFile;
+    public static $static_img_path;
+    public static $static_img_path_perso;
+    public static $static_folder_file_upload;
 
     public function __construct()
     {
@@ -123,6 +126,9 @@ class blockreassurance extends Module implements WidgetInterface
         $this->logo_path = $this->_path . 'logo.png';
         $this->module_path = $this->_path;
         $this->folder_file_upload = _PS_MODULE_DIR_ . $this->name . '/views/img/img_perso/';
+        self::$static_img_path = $this->img_path;
+        self::$static_img_path_perso = $this->img_path_perso;
+        self::$static_folder_file_upload = $this->folder_file_upload;
 
         // Confirm uninstall
         $this->confirmUninstall = $this->trans('Are you sure you want to uninstall this module?', [], 'Modules.Blockreassurance.Admin');
@@ -162,9 +168,9 @@ class blockreassurance extends Module implements WidgetInterface
         ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8;';
 
         $sqlQueries[] = 'INSERT INTO ' . _DB_PREFIX_ . 'psreassurance (icon, custom_icon, status, position, type_link, id_cms, date_add) VALUES '
-            . "('" . $this->img_path . "reassurance/pack2/security.svg', null, 1, 1, null, null, now()),"
-            . "('" . $this->img_path . "reassurance/pack2/carrier.svg', null, 1, 2, null, null, now()),"
-            . "('" . $this->img_path . "reassurance/pack2/parcel.svg', null, 1, 3, null, null, now())";
+            . "('reassurance/pack2/security.svg', null, 1, 1, null, null, now()),"
+            . "('reassurance/pack2/carrier.svg', null, 1, 2, null, null, now()),"
+            . "('reassurance/pack2/parcel.svg', null, 1, 3, null, null, now())";
         foreach (Language::getLanguages(false) as $lang) {
             $sqlQueries[] = 'INSERT INTO ' . _DB_PREFIX_ . 'psreassurance_lang (id_psreassurance, id_lang, title, description, link) VALUES '
                 . '(1, ' . $lang['id_lang'] . ", '" . $this->trans('Security policy', [], 'Modules.Blockreassurance.Shop', $lang['locale']) . "', '" . $this->trans('(edit with the Customer Reassurance module)', [], 'Modules.Blockreassurance.Shop', $lang['locale']) . "', ''),"
@@ -286,6 +292,15 @@ class blockreassurance extends Module implements WidgetInterface
             'actions' => $this->trans('Actions', [], 'Modules.Blockreassurance.Admin'),
         ];
 
+        $allblock = $reassuranceRepository->getAllBlock();
+        foreach ($allblock as &$block) {
+            if ($block['icon']) {
+                $block['icon'] = $this->img_path . $block['icon'];
+            } elseif ($block['custom_icon']) {
+                $block['custom_icon'] = $this->img_path_perso . '/' . $block['custom_icon'];
+            }
+        }
+
         $this->context->smarty->assign([
             'psr_hook_header' => (int) Configuration::get('PSR_HOOK_HEADER'),
             'psr_hook_footer' => (int) Configuration::get('PSR_HOOK_FOOTER'),
@@ -295,7 +310,7 @@ class blockreassurance extends Module implements WidgetInterface
             'psr_icon_color' => Configuration::get('PSR_ICON_COLOR'),
             'logo_path' => $this->logo_path,
             'languages' => Language::getLanguages(false),
-            'allblock' => $reassuranceRepository->getAllBlock(),
+            'allblock' => $allblock,
             'currentPage' => $currentPage,
             'moduleAdminLink' => $moduleAdminLink,
             'img_path' => $this->img_path,

--- a/controllers/admin/AdminBlockListingController.php
+++ b/controllers/admin/AdminBlockListingController.php
@@ -168,13 +168,13 @@ class AdminBlockListingController extends ModuleAdminController
         }
 
         if (strpos($picto, $this->module->img_path_perso) !== false) {
-            if ($picto) {
+            if ($picto != '') {
                 $picto = basename($picto);
             }
             $blockPsr->setIcon('');
             $blockPsr->setCustomIcon($picto);
         } else {
-            if ($picto) {
+            if ($picto != '') {
                 $parts = explode('/', $picto);
                 $parts = array_slice($parts , -3);
                 $picto = implode('/', $parts);
@@ -197,7 +197,7 @@ class AdminBlockListingController extends ModuleAdminController
 
             if (is_bool($validUpload) && $validUpload === false) {
                 // Remove Custom icon
-                if ($blockPsr->getCustomIcon()) {
+                if ($blockPsr->getCustomIcon() != '') {
                     $filePath = blockreassurance::$static_folder_file_upload . '/' . basename($blockPsr->getCustomIcon());
                     if (file_exists($filePath)) {
                         unlink($filePath);

--- a/controllers/admin/AdminBlockListingController.php
+++ b/controllers/admin/AdminBlockListingController.php
@@ -168,9 +168,17 @@ class AdminBlockListingController extends ModuleAdminController
         }
 
         if (strpos($picto, $this->module->img_path_perso) !== false) {
+            if ($picto) {
+                $picto = basename($picto);
+            }
             $blockPsr->setIcon('');
             $blockPsr->setCustomIcon($picto);
         } else {
+            if ($picto) {
+                $parts = explode('/', $picto);
+                $parts = array_slice($parts , -3);
+                $picto = implode('/', $parts);
+            }
             $blockPsr->setIcon($picto);
             $blockPsr->setCustomIcon('');
         }
@@ -188,8 +196,15 @@ class AdminBlockListingController extends ModuleAdminController
             );
 
             if (is_bool($validUpload) && $validUpload === false) {
+                // Remove Custom icon
+                if ($blockPsr->getCustomIcon()) {
+                    $filePath = blockreassurance::$static_folder_file_upload . '/' . basename($blockPsr->getCustomIcon());
+                    if (file_exists($filePath)) {
+                        unlink($filePath);
+                    }
+                }
                 move_uploaded_file($fileTmpName, $this->module->folder_file_upload . $filename);
-                $blockPsr->setCustomIcon($this->module->img_path_perso . '/' . $filename);
+                $blockPsr->setCustomIcon($filename);
                 $blockPsr->setIcon('');
             } else {
                 $errors[] = $validUpload;

--- a/src/Repository/PsreassuranceRepository.php
+++ b/src/Repository/PsreassuranceRepository.php
@@ -138,9 +138,9 @@ class PsreassuranceRepository extends ServiceEntityRepository
             $item['is_svg'] = !empty($item['custom_icon'])
                 && in_array(\ImageManager::getMimeType(\blockreassurance::$static_folder_file_upload . $item['custom_icon']), $xmlMimes);
 
-            if ($item['custom_icon']) {
+            if ($item['custom_icon'] != '') {
                 $item['custom_icon'] = \blockreassurance::$static_img_path_perso . '/' . $item['custom_icon'];
-            } elseif ($item['icon']) {
+            } elseif ($item['icon'] != '') {
                 $item['icon'] = \blockreassurance::$static_img_path . $item['icon'];
             }
         }

--- a/src/Repository/PsreassuranceRepository.php
+++ b/src/Repository/PsreassuranceRepository.php
@@ -136,7 +136,13 @@ class PsreassuranceRepository extends ServiceEntityRepository
         $xmlMimes = ['image/svg', 'image/svg+xml'];
         foreach ($result as &$item) {
             $item['is_svg'] = !empty($item['custom_icon'])
-                && in_array(\ImageManager::getMimeType(_PS_ROOT_DIR_ . $item['custom_icon']), $xmlMimes);
+                && in_array(\ImageManager::getMimeType(\blockreassurance::$static_folder_file_upload . $item['custom_icon']), $xmlMimes);
+
+            if ($item['custom_icon']) {
+                $item['custom_icon'] = \blockreassurance::$static_img_path_perso . '/' . $item['custom_icon'];
+            } elseif ($item['icon']) {
+                $item['icon'] = \blockreassurance::$static_img_path . $item['icon'];
+            }
         }
 
         return $result;

--- a/upgrade/upgrade-6.0.0.php
+++ b/upgrade/upgrade-6.0.0.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * @param blockreassurance $module
+ *
+ * @return bool|string
+ */
+function upgrade_module_6_0_0($module)
+{
+    $sql = 'SELECT * FROM ' . _DB_PREFIX_ . 'psreassurance';
+
+    $rows = Db::getInstance()->executeS($sql);
+
+    foreach ($rows as $row) {
+
+        $data = [];
+
+        if ($row['icon']) {
+
+            $parts = explode('/', $row['icon']);
+            $parts = array_slice($parts , -3);
+
+            $data = [
+                'icon' => implode('/', $parts)
+            ];
+        } elseif ($row['custom_icon']) {
+            $data = [
+                'custom_icon' => basename($row['custom_icon'])
+            ];
+        }
+
+        if ($data) {
+            Db::getInstance()->update('psreassurance', $data, '`id_psreassurance` = ' . (int) $row['id_psreassurance']);
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If images are uploaded while the site is in a subfolder and then the folder name is changed, or the site is moved to the root directory, the uploaded images will no longer be visible.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #[36956](https://github.com/PrestaShop/PrestaShop/issues/36956)
| Sponsor company   | @codencode
| How to test?      | 
