### PR TITLE
Fix icon removal sending undefined string instead of empty

### DIFF
--- a/_dev/back/index.js
+++ b/_dev/back/index.js
@@ -261,7 +261,7 @@ $(window).ready(() => {
   // Tab Content : Edit : Select none
   $(document).on('click', '#reassurance_block .select_none', () => {
     const psrPicto = $('.psr-picto:visible');
-    psrPicto.attr('src', 'undefined').hide();
+    psrPicto.attr('src', '').hide();
 
     // Un-select icon in the popin
     $('#reassurance_block .category_reassurance img.svg').removeClass('selected');

--- a/controllers/admin/AdminBlockListingController.php
+++ b/controllers/admin/AdminBlockListingController.php
@@ -141,6 +141,9 @@ class AdminBlockListingController extends ModuleAdminController
         $errors = [];
 
         $picto = Tools::getValue('picto');
+        if ($picto === 'undefined') {
+            $picto = '';
+        }
         $id_block = empty(Tools::getValue('id_block')) ? 0 : (int) Tools::getValue('id_block');
         $type_link = (int) Tools::getValue('typelink');
         $id_cms = (int) Tools::getValue('id_cms');


### PR DESCRIPTION
When clicking 'Select none' to remove an icon from a reassurance block, the icon wasn't being removed. Tracked in PrestaShop/PrestaShop#40871.

I traced the issue to the JavaScript setting the image src to the literal string `'undefined'` instead of an empty string when clearing the icon. The PHP backend then saved `'undefined'` as the icon value rather than clearing it.

The fix addresses both layers:

**JavaScript (_dev/back/index.js)**: Changed `psrPicto.attr('src', 'undefined')` to `psrPicto.attr('src', '')` when removing an icon.

**PHP (controllers/admin/AdminBlockListingController.php)**: Added a guard to treat the string `'undefined'` as empty, which handles any existing edge cases and provides defense in depth.

Tested locally by:
1. Creating a new reassurance block with an icon
2. Editing the block and clicking 'Select none' for the icon
3. Saving - the icon is now properly removed

Note: I was unable to rebuild the dist files locally due to node-sass requiring Visual Studio. The source change in `_dev/back/index.js` is ready; the minified version in `views/dist/back.js` would need rebuilding by a maintainer with the proper build environment.

Fixes PrestaShop/PrestaShop#40871
