### PR TITLE
Require the upload folder to be writable again

### DIFF
--- a/blockreassurance.php
+++ b/blockreassurance.php
@@ -250,14 +250,24 @@ class blockreassurance extends Module implements WidgetInterface
     }
 
     /**
-     * Check if folder img_perso is writable and executable
+     * Check that the upload folder can actually receive an uploaded file.
      *
      * @return bool
      */
     private function folderUploadFilesHasGoodRights()
     {
-        // do not check is_executable on windows platform (https://www.php.net/manual/en/function.is-executable.php#refsect1-function.is-executable-notes)
-        return is_writable($this->folder_file_upload) && !(preg_match('/^[a-zA-Z]{1}\:{1}\\\\{1}/', $this->folder_file_upload) !== 1) || is_executable($this->folder_file_upload);
+        if (!is_writable($this->folder_file_upload)) {
+            return false;
+        }
+
+        /*
+         * WHY: creating a file inside a directory needs the write permission AND the traverse
+         * permission, so both are required. Windows has no traverse bit, and is_executable() answers
+         * there about file extensions instead, so it reports false for every directory - asking it
+         * would reject a folder that works perfectly well.
+         * https://www.php.net/manual/en/function.is-executable.php#refsect1-function.is-executable-notes
+         */
+        return '\\' === DIRECTORY_SEPARATOR || is_executable($this->folder_file_upload);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | `folderUploadFilesHasGoodRights()` decides whether the configuration page warns that the custom image folder cannot receive uploads, and it stopped enforcing the part that matters. `b93b97d` fixed the Windows false positive with nested conditions and was correct; `a554f0d` flattened it into one expression five days later, and `&&` binds tighter than `\|\|`, so `is_writable($f) && !(preg_match(...) !== 1) \|\| is_executable($f)` reads as `(writable && isWindowsPath) \|\| executable`. On Linux the left side is always false, leaving `is_executable()` alone to decide - and a directory only has to be traversable for that to be true. A folder that is traversable but not writable is reported as fine and the upload then fails. This restores the original meaning and detects the platform instead of matching the path against a drive-letter pattern, which never covered UNC (`\\server\share`) or relative paths.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#33808
| How to test?      | On Linux, point the module's custom image folder at a directory with mode `0555` (readable and traversable, not writable). Before this change the configuration page reports the folder rights as good and a subsequent image upload fails with permission denied; after it, the page reports the folder as not writable, which is what is actually true. A normal `0755` folder is unaffected in both cases.
| Sponsor company   |

## Why not simply drop the is_executable() check

The reporter asked why an image folder should be executable and called it a security risk. On a directory the
execute bit is the *traverse* permission, not permission to run anything, and creating a file inside a
directory needs both write and traverse. So the check is meaningful on Linux and macOS and is kept. It is
Windows that is the special case: it has no traverse bit and `is_executable()` there answers about file
extensions, so it returns false for every directory - which is the false warning originally reported.

## Evidence

The module has no PHPUnit harness (only PHPStan), so this is a measured repro rather than a unit test.

Against real directories, as the web server user, comparing each implementation with the ground truth of
whether `fopen(..., 'w')` actually succeeds inside the folder:

```
directory mode                    truth   current   restored
0755 writable + traversable       ok      ok        ok
0555 read-only, traversable       FAIL    ok        FAIL      <- current lies here
0655 writable, NOT traversable    FAIL    FAIL      FAIL
0000 nothing                      FAIL    FAIL      FAIL

current disagrees with reality: 1/4        restored: 0/4
```

And against the intended pre-flattening logic of `b93b97d`, with the directory separator injected so the
Windows branch is executable on Linux: **0 disagreements out of 8** across both platforms and all four
write/traverse combinations.

cs-fixer with the module's own `.php-cs-fixer.dist.php`: exit 0.
