### PR TITLE
Mark the reassurance icons as decorative

### DIFF
--- a/views/templates/hook/displayBlock.tpl
+++ b/views/templates/hook/displayBlock.tpl
@@ -49,9 +49,9 @@
                 <div class="block-icon">
                     {if $block['icon'] != 'undefined'}
                         {if $block['custom_icon']}
-                          <img {if $block['is_svg']}class="svg invisible" {/if}src="{$block['custom_icon']}">
+                          <img {if $block['is_svg']}class="svg invisible" {/if}src="{$block['custom_icon']}" alt="">
                         {elseif $block['icon']}
-                          <img class="svg invisible" src="{$block['icon']}">
+                          <img class="svg invisible" src="{$block['icon']}" alt="">
                         {/if}
                     {/if}
                 </div>

--- a/views/templates/hook/displayBlockProduct.tpl
+++ b/views/templates/hook/displayBlockProduct.tpl
@@ -23,9 +23,9 @@
             <span class="item-product">
                 {if $block['icon'] != 'undefined'}
                     {if $block['custom_icon']}
-                    <img {if $block['is_svg']}class="svg invisible" {/if}src="{$block['custom_icon']}">
+                    <img {if $block['is_svg']}class="svg invisible" {/if}src="{$block['custom_icon']}" alt="">
                     {elseif $block['icon']}
-                    <img class="svg invisible" src="{$block['icon']}">
+                    <img class="svg invisible" src="{$block['icon']}" alt="">
                     {/if}
                 {/if}&nbsp;
             </span>

--- a/views/templates/hook/displayBlockWhite.tpl
+++ b/views/templates/hook/displayBlockWhite.tpl
@@ -48,9 +48,9 @@
             <div class="block-icon">
                 {if $block['icon'] != 'undefined'}
                     {if $block['custom_icon']}
-                      <img {if $block['is_svg']}class="svg invisible" {/if}src="{$block['custom_icon']}">
+                      <img {if $block['is_svg']}class="svg invisible" {/if}src="{$block['custom_icon']}" alt="">
                     {elseif $block['icon']}
-                      <img class="svg invisible" src="{$block['icon']}">
+                      <img class="svg invisible" src="{$block['icon']}" alt="">
                     {/if}
                 {/if}
             </div>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The six `img` tags in `displayBlock.tpl`, `displayBlockWhite.tpl` and `displayBlockProduct.tpl` carry no `alt` attribute, so SEO crawlers and HTML validators report them as missing and screen readers fall back to announcing the file name. Each icon sits next to the block title and description in the same item, so the image is redundant to adjacent text: it gets `alt=""` rather than a copy of the title, which would make assistive technology read the same words twice.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/30619
| Sponsor company   | None
| How to test?      | Display any reassurance block in the front office and read the rendered markup: every `img` inside `.block-icon` / `.reassurance__image` now carries `alt=""`. The rendered pixels are unchanged. An SEO crawler that reported the block under "missing alt attribute" no longer counts these images.

### Why an empty alt rather than the title

The block markup is icon + title + description in the same element, so the icon adds nothing a reader does not already get from the text next to it. The W3C WAI guidance for images redundant to adjacent text is a null `alt`, which removes the image from the accessibility tree instead of duplicating the title. The same call was made and merged for the payment option logo in the default theme, https://github.com/PrestaShop/hummingbird/pull/1060.

`views/templates/hook/blockreassurance.tpl` already has an `alt`, and so does the `classic-theme` override; the three templates changed here are the ones that were missed.

### History

https://github.com/PrestaShop/blockreassurance/pull/174 named exactly these three files in 2021. It was closed on procedural grounds (opened against `1.7.0.x-prev`, no commits from the author), not on the merits, and the gap was never closed.

